### PR TITLE
fix: disable JWT for webhook and auth-callback

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -386,3 +386,10 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+# Edge Functions – disable JWT verification for externally-called endpoints
+[functions.auth-callback]
+verify_jwt = false
+
+[functions.webhook]
+verify_jwt = false


### PR DESCRIPTION
## Summary

- Disable Supabase JWT verification for `webhook` and `auth-callback` Edge Functions
- These endpoints are called externally (Todoist webhooks and OAuth redirects) without a Supabase JWT
- They handle their own authentication: webhook uses per-user HMAC verification, auth-callback validates the OAuth authorization code

Found during local testing — without this, Supabase returns 401 before our code runs.

## Test plan

- [ ] `curl -X POST http://127.0.0.1:54321/functions/v1/webhook/test` returns 403 "Missing signature" (our HMAC check, not Supabase 401)
- [ ] `curl http://127.0.0.1:54321/functions/v1/auth-callback?code=x` returns 302 redirect (our code runs)
- [ ] `curl http://127.0.0.1:54321/functions/v1/settings` still returns 401 (JWT required, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)