### PR TITLE
Update AI constants and improve image download handling

### DIFF
--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -1,5 +1,5 @@
 import { braveSearch } from "./search.ts";
-import { MAX_TOOL_ROUNDS } from "./constants.ts";
+import { MAX_TOOL_ROUNDS, DEFAULT_MAX_TOKENS } from "./constants.ts";
 import * as Sentry from "npm:@sentry/deno"; // startSpan is a no-op when Sentry is not initialized (no DSN set)
 
 interface Message {
@@ -97,7 +97,7 @@ export async function executePrompt(
   const runMessages = [...messages];
 
   for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
-    const body: any = { model: config.model, messages: runMessages };
+    const body: any = { model: config.model, messages: runMessages, max_tokens: DEFAULT_MAX_TOKENS };
     if (useTools) body.tools = TOOLS;
 
     const controller = new AbortController();
@@ -165,7 +165,7 @@ export async function executePrompt(
           "Content-Type": "application/json",
           Authorization: `Bearer ${config.apiKey}`,
         },
-        body: JSON.stringify({ model: config.model, messages: runMessages }),
+        body: JSON.stringify({ model: config.model, messages: runMessages, max_tokens: DEFAULT_MAX_TOKENS }),
       })
   );
   const data = await res.json();

--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -8,9 +8,10 @@ export const AI_INDICATOR = "🤖 **AI Agent**";
 export const ERROR_PREFIX = "⚠️ AI agent error:";
 export const PROGRESS_INDICATOR = "🤖 **AI Agent**\n\n_Reviewing..._";
 
-export const MAX_TOOL_ROUNDS = 5;
+export const MAX_TOOL_ROUNDS = 3;
 export const DEFAULT_AI_MODEL = "claude-sonnet-4-6";
-export const DEFAULT_MAX_MESSAGES = 20;
+export const DEFAULT_MAX_MESSAGES = 10;
+export const DEFAULT_MAX_TOKENS = 2048;
 
-export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+export const MAX_IMAGE_SIZE_BYTES = 4 * 1024 * 1024; // 4 MB
 export const TODOIST_API_TIMEOUT_MS = 30_000; // 30 seconds

--- a/supabase/functions/webhook/index.ts
+++ b/supabase/functions/webhook/index.ts
@@ -55,19 +55,20 @@ async function handleNoteAdded(event: any, user: any): Promise<void> {
       messages = messages.slice(-maxMessages);
     }
 
-    // Get image attachments from comments
-    const images: { data: string; mediaType: string }[] = [];
-    for (const comment of comments) {
-      const att = comment.file_attachment;
-      if (att?.resource_type === "image") {
-        try {
-          const bytes = await todoist.downloadFile(att.file_url);
-          images.push({ data: uint8ToBase64(bytes), mediaType: att.file_type || "image/png" });
-        } catch (e) {
-          console.error("Failed to download image", att.file_name, e);
-        }
-      }
-    }
+    // Get image attachments from comments (parallel downloads)
+    const imageComments = comments.filter(
+      (c: any) => c.file_attachment?.resource_type === "image"
+    );
+    const imageResults = await Promise.allSettled(
+      imageComments.map(async (c: any) => {
+        const att = c.file_attachment;
+        const bytes = await todoist.downloadFile(att.file_url);
+        return { data: uint8ToBase64(bytes), mediaType: att.file_type || "image/png" };
+      })
+    );
+    const images = imageResults
+      .filter((r): r is PromiseFulfilledResult<{ data: string; mediaType: string }> => r.status === "fulfilled")
+      .map((r) => r.value);
 
     // Build AI config
     const aiConfig = {


### PR DESCRIPTION
- Reduce MAX_TOOL_ROUNDS to 3 and DEFAULT_MAX_MESSAGES to 10
- Add DEFAULT_MAX_TOKENS and set to 2048
- Lower MAX_IMAGE_SIZE_BYTES to 4 MB
- Pass max_tokens to AI requests
- Download image attachments in parallel using Promise.allSettled

## Summary
<!-- What does this PR do? -->

## Test plan
<!-- How was this tested? -->

- [ ] Tests pass locally (`npm run test:unit -- --run`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types check (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
