### PR TITLE
fix: inject Vite env vars during CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Build
         run: cd frontend && npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_TODOIST_CLIENT_ID: ${{ vars.VITE_TODOIST_CLIENT_ID }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary
- The `frontend/.env.production` is gitignored by `*.env*`, so the CI build had no access to `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, or `VITE_TODOIST_CLIENT_ID`
- This caused the Supabase client to fail on initialization, resulting in a blank white page on production (`todoist-ai-agent.pages.dev`)
- Fix: pass the env vars from GitHub repository variables into the build step

## Test plan
- [ ] Verify CI build passes
- [ ] After merge, confirm `todoist-ai-agent.pages.dev` renders the landing page instead of a blank page
- [ ] Confirm the "Connect Todoist" OAuth flow works from the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)