### PR TITLE
fix: add frontend to security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,3 +22,6 @@ jobs:
 
       - run: npm ci
       - run: npm audit --omit=dev
+
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm audit --omit=dev


### PR DESCRIPTION
## Summary
- The weekly security audit only covered root `package.json` dependencies
- `frontend/` has its own `package.json` and `package-lock.json` that were never audited
- Adds `npm ci` + `npm audit --omit=dev` for the frontend directory

## Test plan
- [ ] Verify CI passes (security audit job runs both root and frontend audits)
- [ ] Verified locally: `cd frontend && npm audit --omit=dev` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)