### PR TITLE
chore: add frontend to dependabot and improve branch protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,20 @@ updates:
         dependency-type: production
         update-types: [minor, patch]
 
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      frontend-dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+      frontend-production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- Add `frontend/` directory to dependabot config for automated dependency updates (was only monitoring root)
- Add `deno-tests` to required status checks (previously only `frontend` was required, so broken backend tests wouldn't block merges)
- Enable `dismiss_stale_reviews` on branch protection
- Enable `required_linear_history` for cleaner git history (squash merges)

Note: Branch protection settings (items 2-4) were already applied via GitHub API.

## Test plan
- [ ] Verify CI passes
- [ ] Confirm dependabot picks up frontend dependencies on next Monday run
- [ ] Verify `deno-tests` now shows as required check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)