### PR TITLE
fix: address 360 audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
       - uses: denoland/setup-deno@v2
 
       - name: Run tests
-        run: deno test supabase/functions/tests/ --no-check --allow-env
+        run: deno test supabase/functions/tests/ --allow-env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,21 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   deploy-functions:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,6 +30,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
   deploy-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,8 @@ name: Security Audit
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '0 9 * * 1'
 

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,6 +1,13 @@
 import { createClient } from "@supabase/supabase-js";
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error("Missing VITE_SUPABASE_URL environment variable");
+}
+if (!supabaseAnonKey) {
+  throw new Error("Missing VITE_SUPABASE_ANON_KEY environment variable");
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,14 +6,45 @@ import Settings from "./pages/Settings";
 import AuthCallback from "./pages/AuthCallback";
 import "./index.css";
 
+class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("Uncaught error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+          <p className="text-gray-600">Something went wrong. Please refresh the page.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Landing />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/auth/callback" element={<AuthCallback />} />
-      </Routes>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -17,8 +17,8 @@ export default function AuthCallback() {
       return;
     }
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session) {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (session && (event === 'SIGNED_IN' || event === 'USER_UPDATED')) {
         navigate("/settings");
       }
     });

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -16,6 +16,7 @@ export default function Settings() {
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const [triggerWord, setTriggerWord] = useState("@ai");
   const [aiBaseUrl, setAiBaseUrl] = useState("");
@@ -24,16 +25,22 @@ export default function Settings() {
   const [braveKey, setBraveKey] = useState("");
 
   async function loadSettings(token: string) {
-    const res = await fetch(
-      `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-    if (res.ok) {
-      const data = await res.json();
-      setSettings(data);
-      setTriggerWord(data.trigger_word);
-      setAiBaseUrl(data.custom_ai_base_url || "");
-      setAiModel(data.custom_ai_model || "");
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setSettings(data);
+        setTriggerWord(data.trigger_word);
+        setAiBaseUrl(data.custom_ai_base_url || "");
+        setAiModel(data.custom_ai_model || "");
+      } else {
+        setError("Failed to load settings.");
+      }
+    } catch {
+      setError("Network error. Please check your connection and refresh.");
     }
   }
 
@@ -51,54 +58,79 @@ export default function Settings() {
     setSaving(true);
     setMessage(null);
 
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) return;
-
-    const updates: Record<string, string | null> = {
-      trigger_word: triggerWord,
-      custom_ai_base_url: aiBaseUrl || null,
-      custom_ai_model: aiModel || null,
-    };
-    if (aiApiKey) updates.custom_ai_api_key = aiApiKey;
-    if (braveKey) updates.custom_brave_key = braveKey;
-
-    const res = await fetch(
-      `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
-      {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${session.access_token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updates),
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        setSaving(false);
+        return;
       }
-    );
 
-    setSaving(false);
-    setMessage(res.ok ? "Settings saved." : "Failed to save settings.");
-    if (res.ok) {
-      setAiApiKey("");
-      setBraveKey("");
-      loadSettings(session.access_token);
+      const updates: Record<string, string | null> = {
+        trigger_word: triggerWord,
+        custom_ai_base_url: aiBaseUrl || null,
+        custom_ai_model: aiModel || null,
+      };
+      if (aiApiKey) updates.custom_ai_api_key = aiApiKey;
+      if (braveKey) updates.custom_brave_key = braveKey;
+
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(updates),
+        }
+      );
+
+      setMessage(res.ok ? "Settings saved." : "Failed to save settings.");
+      if (res.ok) {
+        setAiApiKey("");
+        setBraveKey("");
+        loadSettings(session.access_token);
+      }
+    } catch {
+      setMessage("Network error. Please try again.");
+    } finally {
+      setSaving(false);
     }
   }
 
   async function handleDisconnect() {
     if (!confirm("This will delete your account and all data. Continue?")) return;
 
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) return;
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
 
-    await fetch(
-      `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
-      {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${session.access_token}` },
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/settings`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        }
+      );
+
+      if (!res.ok) {
+        setMessage("Failed to delete account. Please try again.");
+        return;
       }
-    );
 
-    await supabase.auth.signOut();
-    navigate("/");
+      await supabase.auth.signOut();
+      navigate("/");
+    } catch {
+      setMessage("Network error. Please try again.");
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-red-600">{error}</p>
+      </div>
+    );
   }
 
   if (!settings) {

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -156,20 +156,34 @@ export async function executePrompt(
   }
 
   // Exhausted tool rounds — get final response without tools
-  const res = await Sentry.startSpan(
-    { name: "ai.chat_completion", op: "ai.chat", attributes: { "ai.model": config.model, "ai.round": "final" } },
-    () =>
-      fetch(`${config.baseUrl}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${config.apiKey}`,
-        },
-        body: JSON.stringify({ model: config.model, messages: runMessages, max_tokens: DEFAULT_MAX_TOKENS }),
-      })
-  );
-  const data = await res.json();
-  return data.choices?.[0]?.message?.content?.trim() || "(no response)";
+  const finalController = new AbortController();
+  const finalTimeout = setTimeout(() => finalController.abort(), config.timeoutMs);
+
+  try {
+    const res = await Sentry.startSpan(
+      { name: "ai.chat_completion", op: "ai.chat", attributes: { "ai.model": config.model, "ai.round": "final" } },
+      () =>
+        fetch(`${config.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.apiKey}`,
+          },
+          body: JSON.stringify({ model: config.model, messages: runMessages, max_tokens: DEFAULT_MAX_TOKENS }),
+          signal: finalController.signal,
+        })
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`AI API error ${res.status}: ${text}`);
+    }
+
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content?.trim() || "(no response)";
+  } finally {
+    clearTimeout(finalTimeout);
+  }
 }
 
 async function handleToolCall(

--- a/supabase/functions/_shared/crypto.ts
+++ b/supabase/functions/_shared/crypto.ts
@@ -25,7 +25,7 @@ export async function getEncryptionKey(): Promise<CryptoKey> {
   const raw = base64ToUint8(b64);
   _cachedKey = await crypto.subtle.importKey(
     "raw",
-    raw,
+    raw.buffer as ArrayBuffer,
     { name: "AES-GCM" },
     false,
     ["encrypt", "decrypt"]

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -55,7 +55,7 @@ export function withSentry(handler: Handler): Handler {
         op: "http.server",
         attributes: {
           "http.method": req.method,
-          "http.url": req.url,
+          "http.url": new URL(req.url).pathname,
         },
       },
       execute

--- a/supabase/functions/_shared/todoist.ts
+++ b/supabase/functions/_shared/todoist.ts
@@ -82,8 +82,18 @@ export class TodoistClient {
       throw new Error(`Todoist updateComment failed: ${res.status}`);
   }
 
+  private isTrustedDomain(url: string): boolean {
+    try {
+      const host = new URL(url).hostname;
+      return host.endsWith(".todoist.com") || host.endsWith(".doist.com") || host.endsWith(".todoist.net");
+    } catch {
+      return false;
+    }
+  }
+
   async downloadFile(url: string): Promise<Uint8Array> {
-    const res = await fetchWithTimeout(url, { headers: this.headers() });
+    const headers = this.isTrustedDomain(url) ? this.headers() : {};
+    const res = await fetchWithTimeout(url, { headers });
     if (!res.ok) throw new Error(`Download failed: ${res.status}`);
 
     if (!res.body) {

--- a/supabase/functions/auth-callback/index.ts
+++ b/supabase/functions/auth-callback/index.ts
@@ -3,7 +3,10 @@ import { TODOIST_TOKEN_URL, TODOIST_SYNC_URL, TODOIST_USER_URL } from "../_share
 import { withSentry, captureException } from "../_shared/sentry.ts";
 import { encrypt } from "../_shared/crypto.ts";
 
-const FRONTEND_URL = Deno.env.get("FRONTEND_URL")!;
+const FRONTEND_URL = Deno.env.get("FRONTEND_URL");
+if (!FRONTEND_URL) {
+  throw new Error("Missing required environment variable: FRONTEND_URL");
+}
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": FRONTEND_URL,
@@ -126,10 +129,14 @@ Deno.serve(withSentry(async (req) => {
 
         if (racedUser) {
           userId = racedUser.id;
-          await supabase
+          const { error: raceUpdateError } = await supabase
             .from("users_config")
             .update({ todoist_token: await encrypt(access_token) })
             .eq("id", userId);
+          if (raceUpdateError) {
+            console.error("Failed to update token (race path):", raceUpdateError);
+            return errorRedirect("update_failed");
+          }
           // Skip webhook + insert — jump straight to magic link
           const { data: linkData, error: linkError } = await supabase.auth.admin.generateLink({
             type: "magiclink",

--- a/supabase/functions/settings/index.ts
+++ b/supabase/functions/settings/index.ts
@@ -3,7 +3,10 @@ import { withSentry } from "../_shared/sentry.ts";
 import { validateSettings } from "../_shared/validation.ts";
 import { encryptIfPresent } from "../_shared/crypto.ts";
 
-const FRONTEND_URL = Deno.env.get("FRONTEND_URL")!;
+const FRONTEND_URL = Deno.env.get("FRONTEND_URL");
+if (!FRONTEND_URL) {
+  throw new Error("Missing required environment variable: FRONTEND_URL");
+}
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": FRONTEND_URL,
@@ -75,7 +78,12 @@ Deno.serve(withSentry(async (req) => {
 
   // ── PUT: Update user settings ──────────────────────────────────────
   if (req.method === "PUT") {
-    const body = await req.json();
+    let body: any;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse({ error: "Invalid JSON body" }, 400);
+    }
 
     const allowedFields = [
       "trigger_word",

--- a/supabase/functions/webhook/index.ts
+++ b/supabase/functions/webhook/index.ts
@@ -140,7 +140,14 @@ Deno.serve(withSentry(async (req: Request) => {
   }
 
   // Verify HMAC immediately — before parsing JSON or querying DB
-  const clientSecret = Deno.env.get("TODOIST_CLIENT_SECRET") ?? "";
+  const clientSecret = Deno.env.get("TODOIST_CLIENT_SECRET");
+  if (!clientSecret) {
+    console.error("TODOIST_CLIENT_SECRET is not configured");
+    return new Response(JSON.stringify({ error: "Server misconfiguration" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
   const valid = await verifyHmac(clientSecret, rawBody, signature);
   if (!valid) {
     return new Response(JSON.stringify({ error: "Invalid signature" }), {
@@ -172,7 +179,7 @@ Deno.serve(withSentry(async (req: Request) => {
   const supabase = createServiceClient();
   const { data: user, error: userErr } = await supabase
     .from("users_config")
-    .select("id, todoist_token, todoist_user_id, webhook_secret, trigger_word, custom_ai_base_url, custom_ai_api_key, custom_ai_model, custom_brave_key, max_messages")
+    .select("id, todoist_token, todoist_user_id, trigger_word, custom_ai_base_url, custom_ai_api_key, custom_ai_model, custom_brave_key, max_messages")
     .eq("todoist_user_id", userId)
     .maybeSingle();
 


### PR DESCRIPTION
## Summary
- Fix all critical, high, and important findings from comprehensive 360 security and quality audit
- 14 files changed across frontend, edge functions, CI/CD workflows

## Changes

### Frontend (4 files)
- **Settings.tsx**: Add try/catch/finally to all async handlers — prevents frozen UI on network errors, validates DELETE response before signing out
- **AuthCallback.tsx**: Filter `onAuthStateChange` by event type (`SIGNED_IN`/`USER_UPDATED`) to prevent stale session navigation
- **supabase.ts**: Validate `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` at startup — clear error instead of cryptic failures
- **main.tsx**: Add React ErrorBoundary — shows user-friendly message instead of blank white screen on render errors

### Edge Functions (7 files)
- **auth-callback**: Validate `FRONTEND_URL` at startup, check update error in race-condition path
- **settings**: Validate `FRONTEND_URL` at startup, guard `req.json()` with try/catch (400 instead of 500)
- **webhook**: Reject missing `TODOIST_CLIENT_SECRET` (500) instead of empty-string fallback, remove unused `webhook_secret` from query
- **todoist.ts**: Validate `file_url` domain before sending auth token (only trusted Todoist domains get Bearer header)
- **ai.ts**: Add timeout + `res.ok` check to final AI round (consistency with in-loop path)
- **sentry.ts**: Strip query params from URLs sent to Sentry
- **crypto.ts**: Cast `Uint8Array` to `ArrayBuffer` for Deno type compat

### CI/CD (3 files)
- **deploy.yml**: Gate on CI success via `workflow_run`, add concurrency control
- **security.yml**: Run audit on PRs (not just push/schedule)
- **ci.yml**: Enable Deno type checking (remove `--no-check`)

### Database (applied directly)
- Dropped redundant index `idx_users_config_todoist_user`
- Optimized RLS policy: `(select auth.uid()) = id`
- Fixed `update_updated_at()` function search_path

## Test plan
- [x] 70/70 Deno unit tests pass (with type checking enabled)
- [x] Frontend lint: 0 errors, 0 warnings
- [x] Frontend build: clean
- [ ] Production browser testing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)