### PR TITLE
fix: polish landing & settings page consistency

### DIFF
--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -75,6 +75,9 @@ export default function Landing() {
 
         <p className="text-center text-xs text-gray-400">
           <a href="https://github.com/viktor-svirsky/todoist-ai-agent" target="_blank" rel="noopener noreferrer" className="hover:text-gray-600 transition-colors">GitHub</a>
+          {" · "}
+          Questions? Open a{" "}
+          <a href="https://github.com/viktor-svirsky/todoist-ai-agent/issues" target="_blank" rel="noopener noreferrer" className="hover:text-gray-600 transition-colors">GitHub issue</a>.
         </p>
       </div>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -158,7 +158,7 @@ export default function Settings() {
             type="text"
             value={triggerWord}
             onChange={(e) => setTriggerWord(e.target.value)}
-            className={inputClasses}
+            className={`${inputClasses} font-mono`}
             placeholder="@ai"
           />
           <p className="mt-1.5 text-xs text-gray-500">


### PR DESCRIPTION
## Summary
- Match landing page footer to settings page by adding "Questions? Open a GitHub issue" link
- Use `font-mono` on the trigger word input in settings to match the `@ai` code badge on the landing page

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Visually confirm landing page footer now shows "GitHub · Questions? Open a GitHub issue."
- [ ] Visually confirm trigger word input on settings page renders in monospace font

🤖 Generated with [Claude Code](https://claude.com/claude-code)