### PR TITLE
fix: link supabase project before db push in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,13 @@ jobs:
         with:
           node-version: 22
 
+      - name: Link Supabase Project
+        run: npx supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - name: Run DB Migrations
-        run: npx supabase db push --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        run: npx supabase db push --linked
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `supabase db push` does not accept `--project-ref` — it requires `supabase link` first
- Add a "Link Supabase Project" step before running migrations in the deploy workflow

## Test plan
- [ ] Merge and verify the deploy workflow succeeds on next push to main