### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it through GitHub's private vulnerability reporting:
+
+1. Go to the [Security Advisories](https://github.com/viktor-svirsky/todoist-ai-agent/security/advisories) page
+2. Click **"Report a vulnerability"**
+3. Provide a description of the vulnerability and steps to reproduce
+
+Please do **not** open a public issue for security vulnerabilities.
+
+You can expect an initial response within 72 hours. We will work with you to understand the issue and coordinate a fix before any public disclosure.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with vulnerability reporting instructions
- Directs users to GitHub's private vulnerability reporting (already enabled)
- Completes the last item in the repository Security Overview

## Test plan
- [ ] Verify "Security policy" shows as enabled in Security Overview after merge