### PR TITLE
fix: return 200 for rate-limited webhooks to prevent Todoist retry loop

### DIFF
--- a/supabase/functions/tests/webhook.test.ts
+++ b/supabase/functions/tests/webhook.test.ts
@@ -210,7 +210,7 @@ t("webhookHandler: returns 404 when user not found", async () => {
 // Rate limiting (requires Supabase mock)
 // ============================================================================
 
-t("webhookHandler: returns 429 when rate limited", async () => {
+t("webhookHandler: returns 200 with rate_limited flag when rate limited", async () => {
   const payload = JSON.stringify(makePayload());
   const req = await signedRequest(payload);
 
@@ -232,14 +232,15 @@ t("webhookHandler: returns 429 when rate limited", async () => {
 
   try {
     const res = await handler(req);
-    assertEquals(res.status, 429);
-    assertEquals(res.headers.get("Retry-After"), "45");
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.rate_limited, true);
   } finally {
     restore();
   }
 });
 
-t("webhookHandler: returns 403 when account blocked", async () => {
+t("webhookHandler: returns 200 with rate_limited flag when account blocked", async () => {
   const payload = JSON.stringify(makePayload());
   const req = await signedRequest(payload);
 
@@ -261,9 +262,9 @@ t("webhookHandler: returns 403 when account blocked", async () => {
 
   try {
     const res = await handler(req);
-    assertEquals(res.status, 403);
+    assertEquals(res.status, 200);
     const body = await res.json();
-    assertEquals(body.error, "Account disabled");
+    assertEquals(body.rate_limited, true);
   } finally {
     restore();
   }

--- a/supabase/functions/webhook/handler.ts
+++ b/supabase/functions/webhook/handler.ts
@@ -10,8 +10,6 @@ import {
 import {
   getRateLimitConfig,
   checkRateLimitByTodoistId,
-  rateLimitResponse,
-  accountBlockedResponse,
 } from "../_shared/rate-limit.ts";
 import { commentsToMessages, normalizeModel } from "../_shared/messages.ts";
 import { captureException } from "../_shared/sentry.ts";
@@ -204,11 +202,12 @@ export async function webhookHandler(req: Request): Promise<Response> {
   // Rate limit check — before any processing or decryption
   const rlConfig = getRateLimitConfig();
   const rlResult = await checkRateLimitByTodoistId(supabase, userId, rlConfig);
-  if (rlResult.blocked) {
-    return accountBlockedResponse();
-  }
-  if (!rlResult.allowed) {
-    return rateLimitResponse(rlResult.retry_after);
+  if (rlResult.blocked || !rlResult.allowed) {
+    // Return 200 so Todoist does not retry — retries of 429 cause an infinite loop
+    return new Response(JSON.stringify({ ok: true, rate_limited: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   const decryptedUser = {


### PR DESCRIPTION
## Summary
- Webhook now returns `200` (with `rate_limited: true` in body) instead of `429`/`403` for rate-limited and blocked requests
- Todoist retries any webhook that returns non-200, which caused an infinite retry loop flooding the edge function
- This was the root cause of users seeing stuck "Reviewing..." progress indicators

## Test plan
- [x] All 201 backend tests pass
- [x] Rate limit test updated to expect 200 with `rate_limited` flag
- [x] Account blocked test updated to expect 200 with `rate_limited` flag
- [ ] Deploy and verify Todoist stops retrying rate-limited webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)