### PR TITLE
Implement CSRF-protected OAuth flow with signed state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Todoist AI Agent — a multi-tenant SaaS that adds AI-powered conversations to T
 ### Key Modules (`supabase/functions/_shared/`)
 
 - `ai.ts` — Dual-provider AI client (Anthropic native + OpenAI-compatible). Auto-detects provider by URL. Handles tool call loop.
-- `crypto.ts` — AES-256-GCM encryption/decryption + HMAC verification for webhook signatures.
+- `crypto.ts` — AES-256-GCM encryption/decryption, HMAC verification for webhook signatures, OAuth state signing/verification.
 - `messages.ts` — Converts Todoist comments to AI conversation messages.
 - `todoist.ts` — Todoist REST API client (comments, tasks, projects, file downloads).
 - `rate-limit.ts` — Per-user rate limiting with account blocking via PostgreSQL function.
@@ -36,7 +36,8 @@ Todoist AI Agent — a multi-tenant SaaS that adds AI-powered conversations to T
 | Function | JWT | Purpose |
 |----------|-----|---------|
 | `webhook` | No | Receives Todoist webhooks, triggers AI responses |
-| `auth-callback` | No | Handles Todoist OAuth token exchange |
+| `auth-start` | No | Initiates Todoist OAuth with HMAC-signed CSRF state |
+| `auth-callback` | No | Handles Todoist OAuth token exchange, verifies CSRF state |
 | `settings` | No* | CRUD for user preferences (validates auth header manually) |
 
 *Settings validates the Authorization header via Supabase user client, not Edge Function JWT verification.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ todoist-ai-agent/
 │       ├── _shared/
 │       │   ├── ai.ts               # Chat completions + tool loop
 │       │   ├── constants.ts        # API URLs, defaults, limits
-│       │   ├── crypto.ts           # AES-256-GCM encryption + HMAC verification
+│       │   ├── crypto.ts           # AES-256-GCM encryption, HMAC verification, OAuth state signing
 │       │   ├── messages.ts         # Comment → message parsing
 │       │   ├── rate-limit.ts       # Per-user rate limiting + account blocking
 │       │   ├── search.ts           # Brave Search client
@@ -137,7 +137,8 @@ todoist-ai-agent/
 │       │   ├── supabase.ts         # Supabase client factories
 │       │   ├── todoist.ts          # Todoist REST API client
 │       │   └── validation.ts       # Input validation
-│       ├── auth-callback/          # OAuth flow handler
+│       ├── auth-start/             # OAuth initiation (CSRF-protected)
+│       ├── auth-callback/          # OAuth completion handler
 │       ├── webhook/                # Todoist webhook processor
 │       ├── settings/               # User config CRUD
 │       └── tests/                  # Deno test suite
@@ -202,7 +203,6 @@ Create **`frontend/.env.local`**:
 ```env
 VITE_SUPABASE_URL=http://127.0.0.1:54321
 VITE_SUPABASE_ANON_KEY=<anon key from supabase start output>
-VITE_TODOIST_CLIENT_ID=your_client_id
 ```
 
 ### 4. Run locally
@@ -255,20 +255,22 @@ deno test supabase/functions/tests/crypto.test.ts --no-check --allow-env --allow
 
 ### Test Coverage
 
-195 tests covering all shared modules and handlers:
+231 tests covering all shared modules and handlers:
 
 | Module | Tests | What's covered |
 |--------|-------|----------------|
 | **ai.ts** | 41 | `buildMessages` (custom prompts, images, edge cases), `executePrompt` (OpenAI + Anthropic providers, tool calls, multi-tool batching) |
+| **validation.ts** | 33 | All settings fields: type checks, boundaries, nulls, multi-field errors, SSRF prevention |
 | **messages.ts** | 30 | Comment parsing, trigger word stripping, special chars, normalize helpers |
 | **rate-limit.ts** | 29 | Config parsing, env overrides, rate limit checks, account blocking |
-| **validation.ts** | 25 | All settings fields: type checks, boundaries, nulls, multi-field errors |
+| **crypto.ts** | 21 | AES-256-GCM encrypt/decrypt round-trips, HMAC verification, OAuth state signing/verification |
+| **webhook** | 21 | HMAC verification, rate limiting, idempotency, request validation |
 | **todoist.ts** | 15 | All TodoistClient methods: API calls, auth headers, error handling, trusted domains |
-| **crypto.ts** | 13 | AES-256-GCM encrypt/decrypt round-trips, HMAC verification, key errors |
 | **settings** | 13 | CRUD operations, auth, rate limiting, field validation |
-| **webhook** | 11 | HMAC verification, rate limiting, request validation |
-| **auth-callback** | 8 | OAuth flow, token exchange, error handling |
+| **auth-callback** | 10 | OAuth flow, token exchange, CSRF state verification, error handling |
 | **search.ts** | 6 | Brave Search: result mapping, params, headers, empty/error responses |
+| **auth-start** | 4 | OAuth initiation, CORS, state signing, error handling |
+| **release-config** | 4 | Release configuration validation |
 | **sentry.ts** | 4 | `withSentry` wrapper, error handling, `captureException` no-op |
 
 ### Linting
@@ -293,6 +295,9 @@ deno lint supabase/functions/   # Deno lint for Edge Functions
 | Measure | Implementation |
 |---------|---------------|
 | **Webhook verification** | HMAC-SHA256 signature on every Todoist webhook |
+| **OAuth CSRF protection** | HMAC-signed state tokens with nonce and expiry |
+| **SSRF prevention** | Private hostname blocking + HTTPS-only for custom AI URLs |
+| **Webhook idempotency** | Atomic event deduplication prevents duplicate AI responses |
 | **Data encryption** | AES-256-GCM for sensitive DB columns (tokens, API keys) |
 | **Data isolation** | PostgreSQL Row Level Security per user |
 | **Authentication** | JWT-based via Supabase Auth |

--- a/deno.lock
+++ b/deno.lock
@@ -2,8 +2,10 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "npm:@sentry/deno@*": "10.41.0"
+    "npm:@sentry/deno@*": "10.41.0",
+    "npm:@sentry/deno@^10.41.0": "10.41.0"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -46,5 +48,11 @@
     "https://esm.sh/iceberg-js@0.8.1/denonext/iceberg-js.mjs": "d839d81a2e3966500ca2cdd0c1cb458e9608bacfc91f7bb67a69b2e878dcdb4f",
     "https://esm.sh/iceberg-js@0.8.1?target=denonext": "58c849d7fe2bf4eca4a84eb501e83c161a7d8c34ca1bec15a962b3bec3062633",
     "https://esm.sh/tslib@2.8.1/denonext/tslib.mjs": "c38da5dd6da6281964435002ce204cd586634fe3bdfb24a0ee116f48cf3292e9"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.19",
+      "npm:@sentry/deno@^10.41.0"
+    ]
   }
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -10,4 +10,8 @@ if (!supabaseAnonKey) {
   throw new Error("Missing VITE_SUPABASE_ANON_KEY environment variable");
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    detectSessionInUrl: false,
+  },
+});

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -6,28 +6,38 @@ export default function AuthCallback() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Verify OAuth state to prevent CSRF
-    const params = new URLSearchParams(window.location.search);
-    const returnedState = params.get("state");
-    const savedState = sessionStorage.getItem("oauth_state");
-    sessionStorage.removeItem("oauth_state");
+    // Verify that the user initiated the OAuth flow from this browser
+    const pending = sessionStorage.getItem("oauth_pending");
+    sessionStorage.removeItem("oauth_pending");
 
-    if (!returnedState || returnedState !== savedState) {
+    if (!pending) {
       navigate("/?error=state_mismatch");
       return;
     }
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-      if (session && (event === 'SIGNED_IN' || event === 'USER_UPDATED')) {
-        navigate("/settings");
-      }
-    });
+    // Manually parse session from URL hash (detectSessionInUrl is disabled)
+    const hash = window.location.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    const accessToken = params.get("access_token");
+    const refreshToken = params.get("refresh_token");
+
+    if (!accessToken || !refreshToken) {
+      navigate("/?error=missing_session");
+      return;
+    }
+
+    supabase.auth
+      .setSession({ access_token: accessToken, refresh_token: refreshToken })
+      .then(({ error }) => {
+        if (error) {
+          navigate("/?error=session_failed");
+        } else {
+          navigate("/settings");
+        }
+      });
 
     const timeout = setTimeout(() => navigate("/?error=timeout"), 10_000);
-    return () => {
-      subscription.unsubscribe();
-      clearTimeout(timeout);
-    };
+    return () => clearTimeout(timeout);
   }, [navigate]);
 
   return (

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -18,17 +18,9 @@ export default function Landing() {
 
   const handleConnect = () => {
     setConnecting(true);
-    const clientId = import.meta.env.VITE_TODOIST_CLIENT_ID;
-    const state = crypto.randomUUID();
-    sessionStorage.setItem("oauth_state", state);
-
-    const params = new URLSearchParams({
-      client_id: clientId,
-      scope: "data:read_write",
-      state,
-    });
-
-    window.location.href = `https://todoist.com/oauth/authorize?${params}`;
+    sessionStorage.setItem("oauth_pending", "true");
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    window.location.href = `${supabaseUrl}/functions/v1/auth-start`;
   };
 
   return (

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -281,7 +281,7 @@ export async function executePrompt(
   const assistantMsg = anthropic ? anthropicAssistantMessage : openaiAssistantMessage;
   const toolResultMsg = anthropic ? anthropicToolResultMessage : openaiToolResultMessage;
 
-  for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const body = buildBody(config.model, runMessages, DEFAULT_MAX_TOKENS, useTools);
 
     const controller = new AbortController();
@@ -373,17 +373,22 @@ async function handleToolCall(
   braveApiKey: string
 ): Promise<string> {
   try {
-    const args = JSON.parse(argsJson);
-
-    if (name === "web_search" || name === "proxy_web_search") {
-      const results = await braveSearch(braveApiKey, args.query, args.count || 5);
-      if (results.length === 0) return "No results found.";
-      return results
-        .map((r) => `**${r.title}**\n${r.url}\n${r.description}`)
-        .join("\n\n");
+    if (name !== "web_search") {
+      return `Unknown tool: ${name}`;
     }
 
-    return `Unknown tool: ${name}`;
+    const args = JSON.parse(argsJson);
+    const query = typeof args.query === "string" ? args.query.slice(0, 500) : "";
+    if (!query) return "Error: search query is required.";
+    const count = typeof args.count === "number"
+      ? Math.min(Math.max(Math.round(args.count), 1), 10)
+      : 5;
+
+    const results = await braveSearch(braveApiKey, query, count);
+    if (results.length === 0) return "No results found.";
+    return results
+      .map((r) => `**${r.title}**\n${r.url}\n${r.description}`)
+      .join("\n\n");
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     return `Tool error: ${message}`;

--- a/supabase/functions/_shared/crypto.ts
+++ b/supabase/functions/_shared/crypto.ts
@@ -99,3 +99,60 @@ export async function verifyHmac(
   }
   return mismatch === 0;
 }
+
+// ---------------------------------------------------------------------------
+// OAuth state signing — HMAC-based self-verifying state tokens
+// Format: nonce.timestamp.signature
+// ---------------------------------------------------------------------------
+
+async function hmacSign(secret: string, data: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(data));
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+function hmacEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+export async function signOAuthState(secret: string): Promise<string> {
+  const nonce = crypto.randomUUID();
+  const ts = Math.floor(Date.now() / 1000);
+  const payload = `${nonce}.${ts}`;
+  const signature = await hmacSign(secret, payload);
+  return `${payload}.${signature}`;
+}
+
+export async function verifyOAuthState(
+  secret: string,
+  state: string,
+  maxAgeSeconds = 600,
+): Promise<boolean> {
+  const parts = state.split(".");
+  if (parts.length !== 3) return false;
+
+  const [, tsStr, signature] = parts;
+  const ts = parseInt(tsStr, 10);
+  if (isNaN(ts)) return false;
+
+  // Reject expired states
+  const now = Math.floor(Date.now() / 1000);
+  if (now - ts > maxAgeSeconds) return false;
+
+  // Verify HMAC signature
+  const payload = `${parts[0]}.${tsStr}`;
+  const computed = await hmacSign(secret, payload);
+  return hmacEqual(computed, signature);
+}

--- a/supabase/functions/_shared/search.ts
+++ b/supabase/functions/_shared/search.ts
@@ -4,6 +4,8 @@ interface SearchResult {
   description: string;
 }
 
+const BRAVE_SEARCH_TIMEOUT_MS = 15_000;
+
 export async function braveSearch(
   apiKey: string,
   query: string,
@@ -13,20 +15,28 @@ export async function braveSearch(
   url.searchParams.set("q", query);
   url.searchParams.set("count", String(count));
 
-  const res = await fetch(url.toString(), {
-    headers: {
-      Accept: "application/json",
-      "Accept-Encoding": "gzip",
-      "X-Subscription-Token": apiKey,
-    },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BRAVE_SEARCH_TIMEOUT_MS);
 
-  if (!res.ok) throw new Error(`Brave search failed: ${res.status}`);
+  try {
+    const res = await fetch(url.toString(), {
+      headers: {
+        Accept: "application/json",
+        "Accept-Encoding": "gzip",
+        "X-Subscription-Token": apiKey,
+      },
+      signal: controller.signal,
+    });
 
-  const data = await res.json();
-  return (data.web?.results || []).map((r: any) => ({
-    title: r.title,
-    url: r.url,
-    description: r.description,
-  }));
+    if (!res.ok) throw new Error(`Brave search failed: ${res.status}`);
+
+    const data = await res.json();
+    return (data.web?.results || []).map((r: any) => ({
+      title: r.title,
+      url: r.url,
+      description: r.description,
+    }));
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/supabase/functions/_shared/validation.ts
+++ b/supabase/functions/_shared/validation.ts
@@ -3,6 +3,28 @@ export interface ValidationError {
   message: string;
 }
 
+export function isPrivateHostname(hostname: string): boolean {
+  if (hostname === "localhost" || hostname === "::1") return true;
+
+  // IPv4 private/reserved ranges
+  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const [a, b] = [Number(ipv4Match[1]), Number(ipv4Match[2])];
+    if (a === 0) return true;                          // 0.0.0.0/8
+    if (a === 10) return true;                         // 10.0.0.0/8
+    if (a === 127) return true;                        // 127.0.0.0/8
+    if (a === 169 && b === 254) return true;           // 169.254.0.0/16 (link-local / AWS metadata)
+    if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;           // 192.168.0.0/16
+  }
+
+  // Cloud metadata hostnames
+  const blocked = ["metadata.google.internal", "metadata.goog"];
+  if (blocked.includes(hostname.toLowerCase())) return true;
+
+  return false;
+}
+
 export function validateSettings(
   updates: Record<string, unknown>
 ): ValidationError[] {
@@ -29,8 +51,10 @@ export function validateSettings(
     } else {
       try {
         const url = new URL(v);
-        if (url.protocol !== "http:" && url.protocol !== "https:") {
-          errors.push({ field: "custom_ai_base_url", message: "Must use http or https protocol" });
+        if (url.protocol !== "https:") {
+          errors.push({ field: "custom_ai_base_url", message: "Must use HTTPS protocol" });
+        } else if (isPrivateHostname(url.hostname)) {
+          errors.push({ field: "custom_ai_base_url", message: "Private or internal URLs are not allowed" });
         }
       } catch {
         errors.push({ field: "custom_ai_base_url", message: "Must be a valid URL" });

--- a/supabase/functions/auth-callback/handler.ts
+++ b/supabase/functions/auth-callback/handler.ts
@@ -1,7 +1,7 @@
 import { createServiceClient } from "../_shared/supabase.ts";
 import { TODOIST_TOKEN_URL, TODOIST_SYNC_URL, TODOIST_USER_URL } from "../_shared/constants.ts";
 import { captureException } from "../_shared/sentry.ts";
-import { encrypt } from "../_shared/crypto.ts";
+import { encrypt, verifyOAuthState } from "../_shared/crypto.ts";
 
 function getFrontendUrl(): string {
   const url = Deno.env.get("FRONTEND_URL");
@@ -49,6 +49,12 @@ export async function authCallbackHandler(req: Request): Promise<Response> {
 
     if (!state) {
       return errorRedirect("missing_state");
+    }
+
+    // Verify HMAC-signed state to prevent CSRF
+    const clientSecret = Deno.env.get("TODOIST_CLIENT_SECRET");
+    if (!clientSecret || !(await verifyOAuthState(clientSecret, state))) {
+      return errorRedirect("invalid_state");
     }
 
     // 1. Exchange code for access token
@@ -229,14 +235,11 @@ export async function authCallbackHandler(req: Request): Promise<Response> {
         // Continue anyway — webhook can be re-registered later
       }
 
-      // 7. Generate webhook secret and insert users_config row
-      const webhookSecret = crypto.randomUUID();
-
+      // 7. Insert users_config row
       const { error: insertError } = await supabase.from("users_config").insert({
         id: userId,
         todoist_token: await encrypt(access_token),
         todoist_user_id: todoistUserId,
-        webhook_secret: await encrypt(webhookSecret),
       });
 
       if (insertError) {

--- a/supabase/functions/auth-start/handler.ts
+++ b/supabase/functions/auth-start/handler.ts
@@ -1,0 +1,45 @@
+import { signOAuthState } from "../_shared/crypto.ts";
+import { TODOIST_OAUTH_URL } from "../_shared/constants.ts";
+
+function getFrontendUrl(): string {
+  const url = Deno.env.get("FRONTEND_URL");
+  if (!url) {
+    throw new Error("Missing required environment variable: FRONTEND_URL");
+  }
+  return url;
+}
+
+export async function authStartHandler(req: Request): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", {
+      headers: {
+        "Access-Control-Allow-Origin": getFrontendUrl(),
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const clientId = Deno.env.get("TODOIST_CLIENT_ID");
+  const clientSecret = Deno.env.get("TODOIST_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    return new Response("Server misconfiguration", { status: 500 });
+  }
+
+  const state = await signOAuthState(clientSecret);
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: "data:read_write",
+    state,
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${TODOIST_OAUTH_URL}?${params}` },
+  });
+}

--- a/supabase/functions/auth-start/index.ts
+++ b/supabase/functions/auth-start/index.ts
@@ -1,0 +1,4 @@
+import { authStartHandler } from "./handler.ts";
+import { withSentry } from "../_shared/sentry.ts";
+
+Deno.serve(withSentry(authStartHandler));

--- a/supabase/functions/tests/auth-callback.test.ts
+++ b/supabase/functions/tests/auth-callback.test.ts
@@ -5,15 +5,17 @@ import { assertEquals } from "@std/assert";
 // ---------------------------------------------------------------------------
 
 const FRONTEND_URL = "https://app.example.com";
+const CLIENT_SECRET = "test-client-secret";
 Deno.env.set("SUPABASE_URL", "http://localhost:54321");
 Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-key");
 Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key");
 Deno.env.set("FRONTEND_URL", FRONTEND_URL);
 Deno.env.set("TODOIST_CLIENT_ID", "test-client-id");
-Deno.env.set("TODOIST_CLIENT_SECRET", "test-client-secret");
+Deno.env.set("TODOIST_CLIENT_SECRET", CLIENT_SECRET);
 Deno.env.set("ENCRYPTION_KEY", btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))));
 
 const { authCallbackHandler: handler } = await import("../auth-callback/handler.ts");
+const { signOAuthState } = await import("../_shared/crypto.ts");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,8 +35,9 @@ function mockFetch(
   return () => { globalThis.fetch = original; };
 }
 
-function callbackUrl(params: Record<string, string> = {}): string {
-  const merged = { code: "oauth-code", state: "csrf-state", ...params };
+async function callbackUrl(params: Record<string, string> = {}): Promise<string> {
+  const validState = await signOAuthState(CLIENT_SECRET);
+  const merged = { code: "oauth-code", state: validState, ...params };
   return `http://localhost/auth-callback?${new URLSearchParams(merged).toString()}`;
 }
 
@@ -101,6 +104,27 @@ t("authCallbackHandler: missing state redirects with error", async () => {
 });
 
 // ============================================================================
+// State validation (CSRF protection)
+// ============================================================================
+
+t("authCallbackHandler: invalid state (forged) redirects with error", async () => {
+  const req = new Request("http://localhost/auth-callback?code=abc&state=forged-state");
+  const res = await handler(req);
+  assertEquals(res.status, 302);
+  const location = res.headers.get("Location")!;
+  assertEquals(location.includes("error=invalid_state"), true);
+});
+
+t("authCallbackHandler: state signed with wrong secret redirects with error", async () => {
+  const wrongState = await signOAuthState("wrong-secret");
+  const req = new Request(`http://localhost/auth-callback?code=abc&state=${encodeURIComponent(wrongState)}`);
+  const res = await handler(req);
+  assertEquals(res.status, 302);
+  const location = res.headers.get("Location")!;
+  assertEquals(location.includes("error=invalid_state"), true);
+});
+
+// ============================================================================
 // External API failures
 // ============================================================================
 
@@ -112,7 +136,7 @@ t("authCallbackHandler: token exchange failure redirects with error", async () =
     return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
   });
   try {
-    const req = new Request(callbackUrl());
+    const req = new Request(await callbackUrl());
     const res = await handler(req);
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("Location")!.includes("error=token_exchange_failed"), true);
@@ -135,7 +159,7 @@ t("authCallbackHandler: profile fetch failure redirects with error", async () =>
     return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
   });
   try {
-    const req = new Request(callbackUrl());
+    const req = new Request(await callbackUrl());
     const res = await handler(req);
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("Location")!.includes("error=profile_fetch_failed"), true);
@@ -181,13 +205,13 @@ t("authCallbackHandler: existing user updates token and redirects with session",
     },
   ));
   try {
-    const req = new Request(callbackUrl());
+    const req = new Request(await callbackUrl());
     const res = await handler(req);
     assertEquals(res.status, 302);
     const location = res.headers.get("Location")!;
     assertEquals(location.includes(`${FRONTEND_URL}/auth/callback`), true);
     assertEquals(location.includes("#access_token=session-access-token"), true);
-    assertEquals(location.includes("state=csrf-state"), true);
+    assertEquals(location.includes("state="), true);
   } finally {
     restore();
   }
@@ -254,7 +278,7 @@ t("authCallbackHandler: new user creates account and redirects with session", as
     },
   ));
   try {
-    const req = new Request(callbackUrl());
+    const req = new Request(await callbackUrl());
     const res = await handler(req);
     assertEquals(res.status, 302);
     const location = res.headers.get("Location")!;
@@ -274,7 +298,7 @@ t("authCallbackHandler: catches internal errors and redirects", async () => {
     throw new Error("Network failure");
   });
   try {
-    const req = new Request(callbackUrl());
+    const req = new Request(await callbackUrl());
     const res = await handler(req);
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("Location")!.includes("error=auth_failed"), true);

--- a/supabase/functions/tests/auth-start.test.ts
+++ b/supabase/functions/tests/auth-start.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from "@std/assert";
+
+// ---------------------------------------------------------------------------
+// Env setup
+// ---------------------------------------------------------------------------
+
+Deno.env.set("FRONTEND_URL", "https://app.example.com");
+Deno.env.set("TODOIST_CLIENT_ID", "test-client-id");
+Deno.env.set("TODOIST_CLIENT_SECRET", "test-client-secret");
+
+const { authStartHandler: handler } = await import("../auth-start/handler.ts");
+
+// ---------------------------------------------------------------------------
+
+Deno.test("authStartHandler: OPTIONS returns CORS headers", async () => {
+  const req = new Request("http://localhost/auth-start", { method: "OPTIONS" });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "https://app.example.com");
+});
+
+Deno.test("authStartHandler: POST returns 405", async () => {
+  const req = new Request("http://localhost/auth-start", { method: "POST" });
+  const res = await handler(req);
+  assertEquals(res.status, 405);
+});
+
+Deno.test("authStartHandler: GET redirects to Todoist OAuth with signed state", async () => {
+  const req = new Request("http://localhost/auth-start", { method: "GET" });
+  const res = await handler(req);
+  assertEquals(res.status, 302);
+
+  const location = res.headers.get("Location")!;
+  assertEquals(location.startsWith("https://todoist.com/oauth/authorize?"), true);
+
+  const url = new URL(location);
+  assertEquals(url.searchParams.get("client_id"), "test-client-id");
+  assertEquals(url.searchParams.get("scope"), "data:read_write");
+
+  // State should be in nonce.timestamp.signature format
+  const state = url.searchParams.get("state")!;
+  const parts = state.split(".");
+  assertEquals(parts.length, 3);
+});
+
+Deno.test("authStartHandler: state is verifiable with the same secret", async () => {
+  const { verifyOAuthState } = await import("../_shared/crypto.ts");
+
+  const req = new Request("http://localhost/auth-start", { method: "GET" });
+  const res = await handler(req);
+  const location = res.headers.get("Location")!;
+  const url = new URL(location);
+  const state = url.searchParams.get("state")!;
+
+  assertEquals(await verifyOAuthState("test-client-secret", state), true);
+  assertEquals(await verifyOAuthState("wrong-secret", state), false);
+});

--- a/supabase/functions/tests/crypto.test.ts
+++ b/supabase/functions/tests/crypto.test.ts
@@ -7,6 +7,8 @@ import {
   encryptIfPresent,
   decryptIfPresent,
   _resetKeyCache,
+  signOAuthState,
+  verifyOAuthState,
 } from "../_shared/crypto.ts";
 
 Deno.test("uint8ToBase64: encodes empty array", () => {
@@ -196,4 +198,77 @@ Deno.test("getEncryptionKey: throws descriptive error when ENCRYPTION_KEY missin
     Error,
     "ENCRYPTION_KEY environment variable is not set"
   );
+});
+
+// ---------------------------------------------------------------------------
+// OAuth state signing / verification
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = "test-oauth-secret";
+
+Deno.test("signOAuthState: produces nonce.timestamp.signature format", async () => {
+  const state = await signOAuthState(TEST_SECRET);
+  const parts = state.split(".");
+  assertEquals(parts.length, 3);
+  // First part is a UUID
+  assertEquals(/^[0-9a-f-]{36}$/.test(parts[0]), true);
+  // Second part is a unix timestamp
+  assertEquals(Number.isInteger(parseInt(parts[1], 10)), true);
+  // Third part is a non-empty base64 signature
+  assertEquals(parts[2].length > 0, true);
+});
+
+Deno.test("verifyOAuthState: accepts valid state", async () => {
+  const state = await signOAuthState(TEST_SECRET);
+  assertEquals(await verifyOAuthState(TEST_SECRET, state), true);
+});
+
+Deno.test("verifyOAuthState: rejects state signed with wrong secret", async () => {
+  const state = await signOAuthState(TEST_SECRET);
+  assertEquals(await verifyOAuthState("wrong-secret", state), false);
+});
+
+Deno.test("verifyOAuthState: rejects tampered nonce", async () => {
+  const state = await signOAuthState(TEST_SECRET);
+  const parts = state.split(".");
+  parts[0] = "00000000-0000-0000-0000-000000000000";
+  assertEquals(await verifyOAuthState(TEST_SECRET, parts.join(".")), false);
+});
+
+Deno.test("verifyOAuthState: rejects tampered timestamp", async () => {
+  const state = await signOAuthState(TEST_SECRET);
+  const parts = state.split(".");
+  parts[1] = "0";
+  assertEquals(await verifyOAuthState(TEST_SECRET, parts.join(".")), false);
+});
+
+Deno.test("verifyOAuthState: rejects expired state", async () => {
+  // Craft a state with a timestamp 601 seconds in the past
+  const nonce = crypto.randomUUID();
+  const oldTs = Math.floor(Date.now() / 1000) - 601;
+  const payload = `${nonce}.${oldTs}`;
+  // Sign it correctly — it should still be rejected due to age
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw", encoder.encode(TEST_SECRET),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const signature = btoa(String.fromCharCode(...new Uint8Array(sig)));
+  const state = `${payload}.${signature}`;
+
+  assertEquals(await verifyOAuthState(TEST_SECRET, state), false);
+});
+
+Deno.test("verifyOAuthState: rejects malformed state", async () => {
+  assertEquals(await verifyOAuthState(TEST_SECRET, ""), false);
+  assertEquals(await verifyOAuthState(TEST_SECRET, "only-one-part"), false);
+  assertEquals(await verifyOAuthState(TEST_SECRET, "two.parts"), false);
+  assertEquals(await verifyOAuthState(TEST_SECRET, "a.not-a-number.c"), false);
+});
+
+Deno.test("signOAuthState: produces unique states", async () => {
+  const a = await signOAuthState(TEST_SECRET);
+  const b = await signOAuthState(TEST_SECRET);
+  assertNotEquals(a, b);
 });

--- a/supabase/functions/tests/validation.test.ts
+++ b/supabase/functions/tests/validation.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { validateSettings } from "../_shared/validation.ts";
+import { validateSettings, isPrivateHostname } from "../_shared/validation.ts";
 
 // -- max_messages --
 
@@ -53,11 +53,66 @@ Deno.test("validateSettings: trigger_word too long", () => {
   assertEquals(errors[0].field, "trigger_word");
 });
 
+// -- isPrivateHostname --
+
+Deno.test("isPrivateHostname: detects localhost", () => {
+  assertEquals(isPrivateHostname("localhost"), true);
+  assertEquals(isPrivateHostname("::1"), true);
+});
+
+Deno.test("isPrivateHostname: detects private IPv4 ranges", () => {
+  assertEquals(isPrivateHostname("10.0.0.1"), true);
+  assertEquals(isPrivateHostname("10.255.255.255"), true);
+  assertEquals(isPrivateHostname("172.16.0.1"), true);
+  assertEquals(isPrivateHostname("172.31.255.255"), true);
+  assertEquals(isPrivateHostname("192.168.0.1"), true);
+  assertEquals(isPrivateHostname("192.168.255.255"), true);
+  assertEquals(isPrivateHostname("127.0.0.1"), true);
+  assertEquals(isPrivateHostname("127.0.0.2"), true);
+  assertEquals(isPrivateHostname("0.0.0.0"), true);
+});
+
+Deno.test("isPrivateHostname: detects link-local / AWS metadata", () => {
+  assertEquals(isPrivateHostname("169.254.169.254"), true);
+  assertEquals(isPrivateHostname("169.254.0.1"), true);
+});
+
+Deno.test("isPrivateHostname: detects cloud metadata hostnames", () => {
+  assertEquals(isPrivateHostname("metadata.google.internal"), true);
+  assertEquals(isPrivateHostname("metadata.goog"), true);
+});
+
+Deno.test("isPrivateHostname: allows public hostnames", () => {
+  assertEquals(isPrivateHostname("api.openai.com"), false);
+  assertEquals(isPrivateHostname("api.anthropic.com"), false);
+  assertEquals(isPrivateHostname("8.8.8.8"), false);
+  assertEquals(isPrivateHostname("172.15.0.1"), false); // just outside 172.16/12
+  assertEquals(isPrivateHostname("172.32.0.1"), false); // just outside 172.16/12
+});
+
 // -- custom_ai_base_url --
 
-Deno.test("validateSettings: valid URLs", () => {
+Deno.test("validateSettings: valid HTTPS URLs", () => {
   assertEquals(validateSettings({ custom_ai_base_url: "https://api.openai.com/v1" }), []);
-  assertEquals(validateSettings({ custom_ai_base_url: "http://localhost:8080" }), []);
+  assertEquals(validateSettings({ custom_ai_base_url: "https://api.anthropic.com/v1" }), []);
+});
+
+Deno.test("validateSettings: HTTP URLs rejected", () => {
+  const errors = validateSettings({ custom_ai_base_url: "http://api.openai.com/v1" });
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0].message, "Must use HTTPS protocol");
+});
+
+Deno.test("validateSettings: localhost URLs rejected", () => {
+  const errors = validateSettings({ custom_ai_base_url: "https://localhost:8080" });
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0].message, "Private or internal URLs are not allowed");
+});
+
+Deno.test("validateSettings: private IP URLs rejected", () => {
+  assertEquals(validateSettings({ custom_ai_base_url: "https://10.0.0.1/v1" }).length, 1);
+  assertEquals(validateSettings({ custom_ai_base_url: "https://192.168.1.1/v1" }).length, 1);
+  assertEquals(validateSettings({ custom_ai_base_url: "https://169.254.169.254" }).length, 1);
 });
 
 Deno.test("validateSettings: null URL allowed", () => {

--- a/supabase/functions/webhook/handler.ts
+++ b/supabase/functions/webhook/handler.ts
@@ -19,14 +19,21 @@ import { uint8ToBase64, verifyHmac, decrypt, decryptIfPresent } from "../_shared
 // Shared AI processing
 // ---------------------------------------------------------------------------
 
+function sanitizeErrorForUser(error: unknown): string {
+  if (error instanceof Error) {
+    const msg = error.message;
+    if (msg.includes("Custom AI URL requires")) return msg;
+    if (msg.includes("AbortError") || msg.includes("abort")) return "Request timed out.";
+    if (/AI API error \d+/.test(msg)) return "AI service returned an error. Check your API key and model settings.";
+  }
+  return "Something went wrong while processing your request.";
+}
+
 async function runAiForTask(
   taskId: string,
   user: any,
   todoistUserId: string,
 ): Promise<void> {
-  const supabase = createServiceClient();
-  await supabase.rpc("increment_ai_requests", { p_todoist_user_id: todoistUserId });
-
   const todoist = new TodoistClient(user.todoist_token);
   const progressCommentId = await todoist.postProgressComment(taskId);
 
@@ -36,6 +43,11 @@ async function runAiForTask(
       todoist.getComments(taskId),
     ]);
 
+    // Never send the default API key to a custom URL (SSRF protection)
+    if (user.custom_ai_base_url && !user.custom_ai_api_key) {
+      throw new Error("Custom AI URL requires a custom API key. Please add your API key in Settings.");
+    }
+
     const triggerWord = user.trigger_word || "@ai";
     const maxMessages = user.max_messages ?? DEFAULT_MAX_MESSAGES;
     let messages = commentsToMessages(comments, triggerWord, progressCommentId);
@@ -43,8 +55,14 @@ async function runAiForTask(
       messages = messages.slice(-maxMessages);
     }
 
+    // Only download images from comments within the message window (#96)
+    const windowCommentIds = new Set(
+      comments.slice(-maxMessages).map((c: any) => c.id)
+    );
     const imageComments = comments.filter(
-      (c: any) => c.file_attachment?.resource_type === "image"
+      (c: any) =>
+        c.file_attachment?.resource_type === "image" &&
+        windowCommentIds.has(c.id)
     );
     const imageResults = await Promise.allSettled(
       imageComments.map(async (c: any) => {
@@ -63,10 +81,9 @@ async function runAiForTask(
         Deno.env.get("DEFAULT_AI_BASE_URL") ||
         "https://api.anthropic.com/v1"
       ).trim().replace(/\/$/, ""),
-      apiKey:
-        user.custom_ai_api_key ||
-        Deno.env.get("DEFAULT_AI_API_KEY") ||
-        "",
+      apiKey: user.custom_ai_base_url
+        ? user.custom_ai_api_key!
+        : (user.custom_ai_api_key || Deno.env.get("DEFAULT_AI_API_KEY") || ""),
       model: normalizeModel(
         user.custom_ai_model ||
         Deno.env.get("DEFAULT_AI_MODEL") ||
@@ -88,14 +105,17 @@ async function runAiForTask(
     );
     const response = await executePrompt(apiMessages, aiConfig);
 
+    // Increment AI request counter only after successful processing (#99)
+    const supabase = createServiceClient();
+    await supabase.rpc("increment_ai_requests", { p_todoist_user_id: todoistUserId });
+
     await todoist.updateComment(progressCommentId, response);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    console.error("AI processing failed", { taskId, error: message });
+    console.error("AI processing failed", { taskId, error: error instanceof Error ? error.message : String(error) });
     try {
       await todoist.updateComment(
         progressCommentId,
-        `${ERROR_PREFIX} ${message}. Retry by adding a comment.`
+        `${ERROR_PREFIX} ${sanitizeErrorForUser(error)} Retry by adding a comment.`
       );
     } catch (e) {
       console.error("Failed to update progress comment with error", e);
@@ -254,6 +274,19 @@ export async function webhookHandler(req: Request): Promise<Response> {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  // Idempotency check — prevent duplicate AI responses from concurrent deliveries
+  const entityId = event.event_data?.id ?? event.event_data?.item_id ?? "";
+  const eventKey = `${userId}:${event.event_name}:${entityId}`;
+  if (eventKey && entityId) {
+    const { data: claimed } = await supabase.rpc("try_claim_event", { p_event_id: eventKey });
+    if (claimed === false) {
+      return new Response(JSON.stringify({ ok: true, deduplicated: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
   }
 
   const decryptedUser = {

--- a/supabase/migrations/00006_webhook_idempotency.sql
+++ b/supabase/migrations/00006_webhook_idempotency.sql
@@ -1,0 +1,31 @@
+-- Webhook event deduplication to prevent duplicate AI responses.
+-- Stores processed event IDs with auto-cleanup of old entries.
+
+CREATE TABLE processed_events (
+  event_id text PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for efficient cleanup of old entries
+CREATE INDEX idx_processed_events_created_at ON processed_events (created_at);
+
+-- Atomically try to claim an event for processing.
+-- Returns true if this call claimed it (proceed), false if already claimed (skip).
+CREATE OR REPLACE FUNCTION try_claim_event(p_event_id text)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Clean up events older than 1 hour (prevents unbounded growth)
+  DELETE FROM processed_events WHERE created_at < now() - interval '1 hour';
+
+  -- Try to insert; ON CONFLICT means it was already claimed
+  INSERT INTO processed_events (event_id) VALUES (p_event_id)
+  ON CONFLICT (event_id) DO NOTHING;
+
+  RETURN FOUND;
+END;
+$$;
+
+-- Also remove the unused webhook_secret column (issue #92)
+ALTER TABLE users_config DROP COLUMN IF EXISTS webhook_secret;


### PR DESCRIPTION
- Add auth-start function to initiate Todoist OAuth with HMAC-signed state
- Update frontend to use new OAuth flow and session handling
- Implement state signing and verification in crypto.ts
- Add isPrivateHostname utility to validation.ts
- Add webhook event deduplication migration for idempotency
- Update docs and tests for new OAuth and security logic

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- List the key changes made -->

-

## Test Plan

<!-- How was this tested? -->

- [ ] Deno tests pass (`npm test`)
- [ ] Frontend lint passes (`cd frontend && npm run lint`)
- [ ] Frontend builds (`npm run frontend:build`)
- [ ] Manually tested locally (if applicable)
