### PR TITLE
feat: add type safety, env validation, and request tracing

### DIFF
--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -1,6 +1,12 @@
 import { braveSearch } from "./search.ts";
 import { MAX_TOOL_ROUNDS, DEFAULT_MAX_TOKENS } from "./constants.ts";
 import * as Sentry from "@sentry/deno"; // startSpan is a no-op when Sentry is not initialized (no DSN set)
+import type {
+  OpenAiResponse,
+  AnthropicResponse,
+  AnthropicContentBlock,
+  ExtractedToolCall,
+} from "./types.ts";
 
 interface Message {
   role: "user" | "assistant";
@@ -19,6 +25,10 @@ export interface AiConfig {
   timeoutMs: number;
   braveApiKey?: string;
 }
+
+// Provider-specific messages accumulate in this array during the tool loop.
+// The shape varies by provider (OpenAI vs Anthropic), so we use a permissive type.
+type ApiMessage = Record<string, unknown>;
 
 const SYSTEM_PROMPT = [
   "You are an AI assistant embedded in Todoist.",
@@ -74,7 +84,7 @@ export function isAnthropicUrl(baseUrl: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// buildMessages (unchanged — produces OpenAI-style messages with system role)
+// buildMessages (produces OpenAI-style messages with system role)
 // ---------------------------------------------------------------------------
 
 export function buildMessages(
@@ -83,7 +93,7 @@ export function buildMessages(
   messages: Message[],
   images?: ImageAttachment[],
   customPrompt?: string | null
-): any[] {
+): ApiMessage[] {
   const taskContext = [
     `Current task: "${taskContent}"`,
     taskDescription ? `Task description: "${taskDescription}"` : "",
@@ -95,7 +105,7 @@ export function buildMessages(
   }
   systemParts.push(taskContext);
 
-  const result: any[] = [
+  const result: ApiMessage[] = [
     { role: "system", content: systemParts.join("\n\n") },
   ];
 
@@ -139,31 +149,32 @@ function openaiHeaders(apiKey: string): Record<string, string> {
   };
 }
 
-function openaiBody(model: string, messages: any[], maxTokens: number, useTools: boolean): any {
-  const body: any = { model, messages, max_tokens: maxTokens };
+function openaiBody(model: string, messages: ApiMessage[], maxTokens: number, useTools: boolean): Record<string, unknown> {
+  const body: Record<string, unknown> = { model, messages, max_tokens: maxTokens };
   if (useTools) body.tools = OPENAI_TOOLS;
   return body;
 }
 
-function openaiExtractContent(data: any): string | null {
+/** Returns text content, null for empty, or undefined to signal tool calls. */
+function openaiExtractContent(data: OpenAiResponse): string | null | undefined {
   const choice = data.choices?.[0];
   if (!choice) return null;
-  if (choice.message.tool_calls && choice.message.tool_calls.length > 0) return undefined as any; // signal: has tool calls
+  if (choice.message.tool_calls && choice.message.tool_calls.length > 0) return undefined;
   return choice.message.content?.trim() || null;
 }
 
-function openaiExtractToolCalls(data: any): Array<{ id: string; name: string; arguments: string }> {
+function openaiExtractToolCalls(data: OpenAiResponse): ExtractedToolCall[] {
   const calls = data.choices?.[0]?.message?.tool_calls || [];
   return calls
-    .filter((tc: any) => tc.type === "function")
-    .map((tc: any) => ({ id: tc.id, name: tc.function.name, arguments: tc.function.arguments }));
+    .filter((tc) => tc.type === "function")
+    .map((tc) => ({ id: tc.id, name: tc.function.name, arguments: tc.function.arguments }));
 }
 
-function openaiAssistantMessage(data: any): any {
-  return data.choices[0].message;
+function openaiAssistantMessage(data: OpenAiResponse): ApiMessage {
+  return data.choices[0].message as unknown as ApiMessage;
 }
 
-function openaiToolResultMessage(toolCallId: string, content: string): any {
+function openaiToolResultMessage(toolCallId: string, content: string): ApiMessage {
   return { role: "tool", tool_call_id: toolCallId, content };
 }
 
@@ -181,22 +192,22 @@ function anthropicHeaders(apiKey: string): Record<string, string> {
   };
 }
 
-function toAnthropicMessages(messages: any[]): { system: string; messages: any[] } {
+function toAnthropicMessages(messages: ApiMessage[]): { system: string; messages: ApiMessage[] } {
   let system = "";
-  const converted: any[] = [];
+  const converted: ApiMessage[] = [];
 
   for (const msg of messages) {
     if (msg.role === "system") {
-      system += (system ? "\n\n" : "") + msg.content;
+      system += (system ? "\n\n" : "") + (msg.content as string);
       continue;
     }
     if (msg.role === "user") {
       if (Array.isArray(msg.content)) {
         // Multimodal content — convert image_url to Anthropic image format
-        const parts = msg.content.map((part: any) => {
+        const parts = (msg.content as Record<string, unknown>[]).map((part) => {
           if (part.type === "image_url") {
-            const url: string = part.image_url.url;
-            const match = url.match(/^data:([^;]+);base64,(.+)$/);
+            const imageUrl = part.image_url as { url: string };
+            const match = imageUrl.url.match(/^data:([^;]+);base64,(.+)$/);
             if (match) {
               return {
                 type: "image",
@@ -226,33 +237,34 @@ function toAnthropicMessages(messages: any[]): { system: string; messages: any[]
   return { system, messages: converted };
 }
 
-function anthropicBody(model: string, messages: any[], maxTokens: number, useTools: boolean): any {
+function anthropicBody(model: string, messages: ApiMessage[], maxTokens: number, useTools: boolean): Record<string, unknown> {
   const { system, messages: converted } = toAnthropicMessages(messages);
-  const body: any = { model, messages: converted, max_tokens: maxTokens };
+  const body: Record<string, unknown> = { model, messages: converted, max_tokens: maxTokens };
   if (system) body.system = system;
   if (useTools) body.tools = ANTHROPIC_TOOLS;
   return body;
 }
 
-function anthropicExtractContent(data: any): string | null {
+/** Returns text content, null for empty, or undefined to signal tool calls. */
+function anthropicExtractContent(data: AnthropicResponse): string | null | undefined {
   if (!data.content || data.content.length === 0) return null;
-  const hasToolUse = data.content.some((b: any) => b.type === "tool_use");
-  if (hasToolUse) return undefined as any; // signal: has tool calls
-  const textBlocks = data.content.filter((b: any) => b.type === "text");
-  return textBlocks.map((b: any) => b.text).join("\n").trim() || null;
+  const hasToolUse = data.content.some((b: AnthropicContentBlock) => b.type === "tool_use");
+  if (hasToolUse) return undefined;
+  const textBlocks = data.content.filter((b: AnthropicContentBlock): b is { type: "text"; text: string } => b.type === "text");
+  return textBlocks.map((b) => b.text).join("\n").trim() || null;
 }
 
-function anthropicExtractToolCalls(data: any): Array<{ id: string; name: string; arguments: string }> {
+function anthropicExtractToolCalls(data: AnthropicResponse): ExtractedToolCall[] {
   return (data.content || [])
-    .filter((b: any) => b.type === "tool_use")
-    .map((b: any) => ({ id: b.id, name: b.name, arguments: JSON.stringify(b.input) }));
+    .filter((b: AnthropicContentBlock): b is { type: "tool_use"; id: string; name: string; input: Record<string, unknown> } => b.type === "tool_use")
+    .map((b) => ({ id: b.id, name: b.name, arguments: JSON.stringify(b.input) }));
 }
 
-function anthropicAssistantMessage(data: any): any {
+function anthropicAssistantMessage(data: AnthropicResponse): ApiMessage {
   return { role: "assistant", content: data.content };
 }
 
-function anthropicToolResultMessage(toolCallId: string, content: string): any {
+function anthropicToolResultMessage(toolCallId: string, content: string): ApiMessage {
   return {
     role: "user",
     content: [{ type: "tool_result", tool_use_id: toolCallId, content }],
@@ -264,7 +276,7 @@ function anthropicToolResultMessage(toolCallId: string, content: string): any {
 // ---------------------------------------------------------------------------
 
 export async function executePrompt(
-  messages: any[],
+  messages: ApiMessage[],
   config: AiConfig
 ): Promise<string> {
   const anthropic = isAnthropicUrl(config.baseUrl);
@@ -320,7 +332,7 @@ export async function executePrompt(
       const toolCalls = extractToolCalls(data);
       if (anthropic) {
         // Anthropic requires all tool results in a single user message
-        const toolResults: any[] = [];
+        const toolResults: { type: string; tool_use_id: string; content: string }[] = [];
         for (const tc of toolCalls) {
           const result = await handleToolCall(tc.name, tc.arguments, config.braveApiKey!);
           toolResults.push({ type: "tool_result", tool_use_id: tc.id, content: result });

--- a/supabase/functions/_shared/env.ts
+++ b/supabase/functions/_shared/env.ts
@@ -1,0 +1,43 @@
+/** Validate that required environment variables are set and non-empty.
+ *  Throws immediately with all missing vars listed, rather than failing
+ *  at runtime with confusing errors.
+ */
+export function validateEnv(required: string[]): void {
+  const missing = required.filter((key) => {
+    const value = Deno.env.get(key);
+    return value === undefined || value.trim() === "";
+  });
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variable(s): ${missing.join(", ")}`
+    );
+  }
+}
+
+/** Validate that ENCRYPTION_KEY is present and decodes to exactly 32 bytes. */
+export function validateEncryptionKey(): void {
+  const b64 = Deno.env.get("ENCRYPTION_KEY");
+  if (!b64 || b64.trim() === "") {
+    throw new Error(
+      "ENCRYPTION_KEY environment variable is not set. " +
+      'Generate one with: deno -e "console.log(btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))))"'
+    );
+  }
+  try {
+    const binary = atob(b64);
+    if (binary.length !== 32) {
+      throw new Error(
+        `ENCRYPTION_KEY must decode to exactly 32 bytes (got ${binary.length}). ` +
+        'Generate a valid key with: deno -e "console.log(btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))))"'
+      );
+    }
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("ENCRYPTION_KEY must decode")) {
+      throw e;
+    }
+    throw new Error(
+      "ENCRYPTION_KEY is not valid base64. " +
+      'Generate a valid key with: deno -e "console.log(btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))))"'
+    );
+  }
+}

--- a/supabase/functions/_shared/messages.ts
+++ b/supabase/functions/_shared/messages.ts
@@ -1,4 +1,5 @@
 import { AI_INDICATOR, ERROR_PREFIX, PROGRESS_INDICATOR } from "./constants.ts";
+import type { TodoistComment } from "./types.ts";
 
 export interface Message {
   role: "user" | "assistant";
@@ -11,7 +12,7 @@ export interface Message {
  *  - In-flight progress comments and error comments are skipped.
  */
 export function commentsToMessages(
-  comments: any[],
+  comments: TodoistComment[],
   triggerWord: string,
   progressCommentId: string
 ): Message[] {

--- a/supabase/functions/_shared/search.ts
+++ b/supabase/functions/_shared/search.ts
@@ -31,7 +31,7 @@ export async function braveSearch(
     if (!res.ok) throw new Error(`Brave search failed: ${res.status}`);
 
     const data = await res.json();
-    return (data.web?.results || []).map((r: any) => ({
+    return (data.web?.results || []).map((r: Record<string, string>) => ({
       title: r.title,
       url: r.url,
       description: r.description,

--- a/supabase/functions/_shared/types.ts
+++ b/supabase/functions/_shared/types.ts
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------
+// Todoist API types
+// ---------------------------------------------------------------------------
+
+export interface TodoistFileAttachment {
+  resource_type: string;
+  file_url: string;
+  file_type: string;
+}
+
+export interface TodoistComment {
+  id: string;
+  content: string;
+  posted_at: string;
+  file_attachment?: TodoistFileAttachment;
+}
+
+export interface TodoistTask {
+  id: string;
+  content: string;
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Webhook event types
+// ---------------------------------------------------------------------------
+
+export interface TodoistNoteEventData {
+  id?: string;
+  content: string;
+  item_id: string;
+  file_attachment?: TodoistFileAttachment;
+}
+
+export interface TodoistItemEventData {
+  id: string;
+  content: string;
+  description: string;
+  labels: string[];
+}
+
+export interface TodoistWebhookEvent {
+  event_name: string;
+  user_id: number | string;
+  event_data: TodoistNoteEventData | TodoistItemEventData;
+}
+
+// ---------------------------------------------------------------------------
+// User config (from users_config DB table)
+// ---------------------------------------------------------------------------
+
+export interface UserConfig {
+  id: string;
+  todoist_token: string;
+  todoist_user_id: string;
+  trigger_word: string | null;
+  custom_ai_base_url: string | null;
+  custom_ai_api_key: string | null;
+  custom_ai_model: string | null;
+  custom_brave_key: string | null;
+  max_messages: number | null;
+  custom_prompt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// AI message types (OpenAI-compatible format)
+// ---------------------------------------------------------------------------
+
+export interface TextMessagePart {
+  type: "text";
+  text: string;
+}
+
+export interface ImageUrlMessagePart {
+  type: "image_url";
+  image_url: { url: string };
+}
+
+export type MultimodalContentPart = TextMessagePart | ImageUrlMessagePart;
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | MultimodalContentPart[];
+  tool_calls?: OpenAiToolCall[];
+  tool_call_id?: string;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI API types
+// ---------------------------------------------------------------------------
+
+export interface OpenAiToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+export interface OpenAiChoice {
+  message: {
+    content: string | null;
+    role: string;
+    tool_calls?: OpenAiToolCall[];
+  };
+}
+
+export interface OpenAiResponse {
+  choices: OpenAiChoice[];
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic API types
+// ---------------------------------------------------------------------------
+
+export interface AnthropicTextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface AnthropicToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface AnthropicImageBlock {
+  type: "image";
+  source: { type: "base64"; media_type: string; data: string };
+}
+
+export interface AnthropicToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+}
+
+export type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | AnthropicImageBlock
+  | AnthropicToolResultBlock;
+
+export interface AnthropicResponse {
+  content: AnthropicContentBlock[];
+}
+
+// ---------------------------------------------------------------------------
+// Extracted tool call (unified across providers)
+// ---------------------------------------------------------------------------
+
+export interface ExtractedToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}

--- a/supabase/functions/auth-callback/handler.ts
+++ b/supabase/functions/auth-callback/handler.ts
@@ -128,7 +128,7 @@ export async function authCallbackHandler(req: Request): Promise<Response> {
         // Race condition: another OAuth flow already created this user
         const isEmailExists =
           authError.message?.includes("already been registered") ||
-          (authError as any).status === 422;
+          (authError as unknown as { status?: number }).status === 422;
 
         if (!isEmailExists) {
           console.error("Failed to create auth user:", authError);
@@ -193,7 +193,7 @@ export async function authCallbackHandler(req: Request): Promise<Response> {
           console.error("Could not find existing auth user after email_exists error");
           return errorRedirect("user_creation_failed");
         }
-        const found = users.find((u: any) => u.email === email);
+        const found = users.find((u) => u.email === email);
         if (!found) {
           return errorRedirect("user_creation_failed");
         }

--- a/supabase/functions/auth-callback/index.ts
+++ b/supabase/functions/auth-callback/index.ts
@@ -1,4 +1,15 @@
 import { authCallbackHandler } from "./handler.ts";
 import { withSentry } from "../_shared/sentry.ts";
+import { validateEnv, validateEncryptionKey } from "../_shared/env.ts";
+
+validateEnv([
+  "TODOIST_CLIENT_ID",
+  "TODOIST_CLIENT_SECRET",
+  "FRONTEND_URL",
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+]);
+validateEncryptionKey();
 
 Deno.serve(withSentry(authCallbackHandler));

--- a/supabase/functions/auth-start/index.ts
+++ b/supabase/functions/auth-start/index.ts
@@ -1,4 +1,7 @@
 import { authStartHandler } from "./handler.ts";
 import { withSentry } from "../_shared/sentry.ts";
+import { validateEnv } from "../_shared/env.ts";
+
+validateEnv(["TODOIST_CLIENT_ID", "TODOIST_CLIENT_SECRET", "FRONTEND_URL"]);
 
 Deno.serve(withSentry(authStartHandler));

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -6,7 +6,7 @@
   },
   "lint": {
     "rules": {
-      "exclude": ["no-explicit-any", "require-await"]
+      "exclude": ["require-await"]
     }
   }
 }

--- a/supabase/functions/settings/handler.ts
+++ b/supabase/functions/settings/handler.ts
@@ -103,7 +103,7 @@ export async function settingsHandler(req: Request): Promise<Response> {
 
   // ── PUT: Update user settings ──────────────────────────────────────
   if (req.method === "PUT") {
-    let body: any;
+    let body: Record<string, unknown>;
     try {
       body = await req.json();
     } catch {

--- a/supabase/functions/settings/index.ts
+++ b/supabase/functions/settings/index.ts
@@ -1,4 +1,8 @@
 import { settingsHandler } from "./handler.ts";
 import { withSentry } from "../_shared/sentry.ts";
+import { validateEnv, validateEncryptionKey } from "../_shared/env.ts";
+
+validateEnv(["FRONTEND_URL", "SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_SERVICE_ROLE_KEY"]);
+validateEncryptionKey();
 
 Deno.serve(withSentry(settingsHandler));

--- a/supabase/functions/tests/ai.test.ts
+++ b/supabase/functions/tests/ai.test.ts
@@ -428,8 +428,8 @@ Deno.test("executePrompt (Anthropic): trims whitespace from response", async () 
 Deno.test("executePrompt (Anthropic): sends x-api-key header, not Bearer", async () => {
   let capturedHeaders: Record<string, string> = {};
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = ((_input: unknown, init?: any) => {
-    capturedHeaders = init?.headers || {};
+  globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+    capturedHeaders = (init?.headers || {}) as Record<string, string>;
     return Promise.resolve(new Response(JSON.stringify({
       content: [{ type: "text", text: "ok" }],
     }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -445,10 +445,10 @@ Deno.test("executePrompt (Anthropic): sends x-api-key header, not Bearer", async
 });
 
 Deno.test("executePrompt (Anthropic): sends system as top-level param, not in messages", async () => {
-  let capturedBody: any = {};
+  let capturedBody: Record<string, unknown> = {};
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = ((_input: unknown, init?: any) => {
-    capturedBody = JSON.parse(init?.body || "{}");
+  globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+    capturedBody = JSON.parse((init?.body as string) || "{}");
     return Promise.resolve(new Response(JSON.stringify({
       content: [{ type: "text", text: "ok" }],
     }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -459,8 +459,8 @@ Deno.test("executePrompt (Anthropic): sends system as top-level param, not in me
       { role: "user", content: "hello" },
     ];
     await executePrompt(messages, ANTHROPIC_CONFIG);
-    assertStringIncludes(capturedBody.system, "You are helpful");
-    const hasSystemMsg = capturedBody.messages.some((m: any) => m.role === "system");
+    assertStringIncludes(capturedBody.system as string, "You are helpful");
+    const hasSystemMsg = (capturedBody.messages as Record<string, unknown>[]).some((m) => m.role === "system");
     assertEquals(hasSystemMsg, false);
   } finally {
     globalThis.fetch = originalFetch;
@@ -468,7 +468,7 @@ Deno.test("executePrompt (Anthropic): sends system as top-level param, not in me
 });
 
 Deno.test("executePrompt (Anthropic): batches multiple tool results into single user message", async () => {
-  const capturedBodies: any[] = [];
+  const capturedBodies: Record<string, unknown>[] = [];
   const originalFetch = globalThis.fetch;
   let callIndex = 0;
   const responses = [
@@ -492,8 +492,8 @@ Deno.test("executePrompt (Anthropic): batches multiple tool results into single 
       body: { content: [{ type: "text", text: "Combined results" }] },
     },
   ];
-  globalThis.fetch = ((_input: unknown, init?: any) => {
-    capturedBodies.push(JSON.parse(init?.body || "{}"));
+  globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+    capturedBodies.push(JSON.parse((init?.body as string) || "{}"));
     const response = responses[callIndex++] || responses[responses.length - 1];
     return Promise.resolve(new Response(JSON.stringify(response.body), {
       status: response.status,
@@ -506,8 +506,8 @@ Deno.test("executePrompt (Anthropic): batches multiple tool results into single 
     assertEquals(result, "Combined results");
     // Fourth request (2nd AI call) should have tool results batched in a single user message
     const secondBody = capturedBodies[3];
-    const toolResultMsgs = secondBody.messages.filter(
-      (m: any) => m.role === "user" && Array.isArray(m.content) && m.content.some((c: any) => c.type === "tool_result")
+    const toolResultMsgs = (secondBody.messages as Record<string, unknown>[]).filter(
+      (m) => m.role === "user" && Array.isArray(m.content) && (m.content as Record<string, unknown>[]).some((c) => c.type === "tool_result")
     );
     // Should be exactly 1 user message containing both tool results
     assertEquals(toolResultMsgs.length, 1);
@@ -522,7 +522,7 @@ Deno.test("executePrompt (Anthropic): batches multiple tool results into single 
 Deno.test("executePrompt (Anthropic): sends to /v1/messages endpoint", async () => {
   let capturedUrl = "";
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = ((input: unknown, _init?: any) => {
+  globalThis.fetch = ((input: unknown, _init?: RequestInit) => {
     capturedUrl = String(input);
     return Promise.resolve(new Response(JSON.stringify({
       content: [{ type: "text", text: "ok" }],

--- a/supabase/functions/tests/env.test.ts
+++ b/supabase/functions/tests/env.test.ts
@@ -1,0 +1,159 @@
+import { assertThrows } from "@std/assert";
+import { validateEnv, validateEncryptionKey } from "../_shared/env.ts";
+
+// ---------------------------------------------------------------------------
+// validateEnv
+// ---------------------------------------------------------------------------
+
+Deno.test("validateEnv: passes when all vars are set", () => {
+  Deno.env.set("TEST_VAR_A", "value-a");
+  Deno.env.set("TEST_VAR_B", "value-b");
+  try {
+    validateEnv(["TEST_VAR_A", "TEST_VAR_B"]);
+  } finally {
+    Deno.env.delete("TEST_VAR_A");
+    Deno.env.delete("TEST_VAR_B");
+  }
+});
+
+Deno.test("validateEnv: throws when a var is missing", () => {
+  Deno.env.set("TEST_VAR_A", "value-a");
+  Deno.env.delete("TEST_VAR_MISSING");
+  try {
+    assertThrows(
+      () => validateEnv(["TEST_VAR_A", "TEST_VAR_MISSING"]),
+      Error,
+      "TEST_VAR_MISSING"
+    );
+  } finally {
+    Deno.env.delete("TEST_VAR_A");
+  }
+});
+
+Deno.test("validateEnv: throws when a var is empty string", () => {
+  Deno.env.set("TEST_VAR_EMPTY", "");
+  try {
+    assertThrows(
+      () => validateEnv(["TEST_VAR_EMPTY"]),
+      Error,
+      "TEST_VAR_EMPTY"
+    );
+  } finally {
+    Deno.env.delete("TEST_VAR_EMPTY");
+  }
+});
+
+Deno.test("validateEnv: throws when a var is whitespace only", () => {
+  Deno.env.set("TEST_VAR_WHITESPACE", "   ");
+  try {
+    assertThrows(
+      () => validateEnv(["TEST_VAR_WHITESPACE"]),
+      Error,
+      "TEST_VAR_WHITESPACE"
+    );
+  } finally {
+    Deno.env.delete("TEST_VAR_WHITESPACE");
+  }
+});
+
+Deno.test("validateEnv: lists all missing vars in error message", () => {
+  Deno.env.delete("MISSING_1");
+  Deno.env.delete("MISSING_2");
+  try {
+    assertThrows(
+      () => validateEnv(["MISSING_1", "MISSING_2"]),
+      Error,
+      "MISSING_1, MISSING_2"
+    );
+  } finally {
+    // cleanup not needed for missing vars
+  }
+});
+
+Deno.test("validateEnv: empty required list passes", () => {
+  validateEnv([]);
+});
+
+// ---------------------------------------------------------------------------
+// validateEncryptionKey
+// ---------------------------------------------------------------------------
+
+Deno.test("validateEncryptionKey: passes with valid 32-byte base64 key", () => {
+  const key = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))));
+  Deno.env.set("ENCRYPTION_KEY", key);
+  try {
+    validateEncryptionKey();
+  } finally {
+    Deno.env.delete("ENCRYPTION_KEY");
+  }
+});
+
+Deno.test("validateEncryptionKey: throws when ENCRYPTION_KEY is missing", () => {
+  const original = Deno.env.get("ENCRYPTION_KEY");
+  Deno.env.delete("ENCRYPTION_KEY");
+  try {
+    assertThrows(
+      () => validateEncryptionKey(),
+      Error,
+      "ENCRYPTION_KEY environment variable is not set"
+    );
+  } finally {
+    if (original) Deno.env.set("ENCRYPTION_KEY", original);
+  }
+});
+
+Deno.test("validateEncryptionKey: throws when ENCRYPTION_KEY is empty", () => {
+  Deno.env.set("ENCRYPTION_KEY", "");
+  try {
+    assertThrows(
+      () => validateEncryptionKey(),
+      Error,
+      "ENCRYPTION_KEY environment variable is not set"
+    );
+  } finally {
+    Deno.env.delete("ENCRYPTION_KEY");
+  }
+});
+
+Deno.test("validateEncryptionKey: throws when key decodes to wrong length", () => {
+  // 16 bytes instead of 32
+  const shortKey = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))));
+  Deno.env.set("ENCRYPTION_KEY", shortKey);
+  try {
+    assertThrows(
+      () => validateEncryptionKey(),
+      Error,
+      "must decode to exactly 32 bytes"
+    );
+  } finally {
+    Deno.env.delete("ENCRYPTION_KEY");
+  }
+});
+
+Deno.test("validateEncryptionKey: throws when key is invalid base64", () => {
+  Deno.env.set("ENCRYPTION_KEY", "not-valid-base64!!!");
+  try {
+    assertThrows(
+      () => validateEncryptionKey(),
+      Error,
+      "not valid base64"
+    );
+  } finally {
+    Deno.env.delete("ENCRYPTION_KEY");
+  }
+});
+
+Deno.test("validateEncryptionKey: throws when key decodes to 64 bytes", () => {
+  // 64 bytes — too long
+  const longKey = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(64))));
+  Deno.env.set("ENCRYPTION_KEY", longKey);
+  try {
+    assertThrows(
+      () => validateEncryptionKey(),
+      Error,
+      "must decode to exactly 32 bytes"
+    );
+  } finally {
+    Deno.env.delete("ENCRYPTION_KEY");
+  }
+});

--- a/supabase/functions/tests/webhook.test.ts
+++ b/supabase/functions/tests/webhook.test.ts
@@ -372,6 +372,8 @@ t("webhookHandler: accepts valid request and returns 200", async () => {
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(body.ok, true);
+    assertEquals(typeof body.request_id, "string");
+    assertEquals(body.request_id.length, 36); // UUID format
   } finally {
     restore();
   }

--- a/supabase/functions/webhook/handler.ts
+++ b/supabase/functions/webhook/handler.ts
@@ -14,6 +14,7 @@ import {
 import { commentsToMessages, normalizeModel } from "../_shared/messages.ts";
 import { captureException } from "../_shared/sentry.ts";
 import { uint8ToBase64, verifyHmac, decrypt, decryptIfPresent } from "../_shared/crypto.ts";
+import type { TodoistComment, TodoistWebhookEvent, UserConfig } from "../_shared/types.ts";
 
 // ---------------------------------------------------------------------------
 // Shared AI processing
@@ -31,8 +32,9 @@ function sanitizeErrorForUser(error: unknown): string {
 
 async function runAiForTask(
   taskId: string,
-  user: any,
+  user: UserConfig,
   todoistUserId: string,
+  requestId: string,
 ): Promise<void> {
   const todoist = new TodoistClient(user.todoist_token);
   const progressCommentId = await todoist.postProgressComment(taskId);
@@ -57,16 +59,16 @@ async function runAiForTask(
 
     // Only download images from comments within the message window (#96)
     const windowCommentIds = new Set(
-      comments.slice(-maxMessages).map((c: any) => c.id)
+      comments.slice(-maxMessages).map((c: TodoistComment) => c.id)
     );
     const imageComments = comments.filter(
-      (c: any) =>
+      (c: TodoistComment) =>
         c.file_attachment?.resource_type === "image" &&
         windowCommentIds.has(c.id)
     );
     const imageResults = await Promise.allSettled(
-      imageComments.map(async (c: any) => {
-        const att = c.file_attachment;
+      imageComments.map(async (c: TodoistComment) => {
+        const att = c.file_attachment!;
         const bytes = await todoist.downloadFile(att.file_url);
         return { data: uint8ToBase64(bytes), mediaType: att.file_type || "image/png" };
       })
@@ -111,14 +113,14 @@ async function runAiForTask(
 
     await todoist.updateComment(progressCommentId, response);
   } catch (error) {
-    console.error("AI processing failed", { taskId, error: error instanceof Error ? error.message : String(error) });
+    console.error("AI processing failed", { requestId, taskId, error: error instanceof Error ? error.message : String(error) });
     try {
       await todoist.updateComment(
         progressCommentId,
         `${ERROR_PREFIX} ${sanitizeErrorForUser(error)} Retry by adding a comment.`
       );
     } catch (e) {
-      console.error("Failed to update progress comment with error", e);
+      console.error("Failed to update progress comment with error", { requestId, error: e });
     }
     await captureException(error);
   }
@@ -128,13 +130,13 @@ async function runAiForTask(
 // Event handlers
 // ---------------------------------------------------------------------------
 
-async function handleNoteEvent(event: any, user: any): Promise<void> {
+async function handleNoteEvent(event: TodoistWebhookEvent, user: UserConfig, requestId: string): Promise<void> {
   const { event_data } = event;
-  const taskId = event_data.item_id;
+  const taskId = "item_id" in event_data ? event_data.item_id : undefined;
   const content: string = event_data.content ?? "";
 
   if (!taskId || !content) {
-    console.warn("Missing required fields in note event");
+    console.warn("Missing required fields in note event", { requestId });
     return;
   }
 
@@ -151,18 +153,18 @@ async function handleNoteEvent(event: any, user: any): Promise<void> {
   );
   if (!triggerRegex.test(content)) return;
 
-  await runAiForTask(taskId, user, String(event.user_id));
+  await runAiForTask(taskId, user, String(event.user_id), requestId);
 }
 
-async function handleItemEvent(event: any, user: any): Promise<void> {
+async function handleItemEvent(event: TodoistWebhookEvent, user: UserConfig, requestId: string): Promise<void> {
   const { event_data } = event;
-  const taskId = event_data.id;
+  const taskId = "id" in event_data ? event_data.id : undefined;
   const content: string = event_data.content ?? "";
-  const description: string = event_data.description ?? "";
-  const labels: string[] = event_data.labels ?? [];
+  const description: string = "description" in event_data ? (event_data.description ?? "") : "";
+  const labels: string[] = "labels" in event_data ? (event_data.labels ?? []) : [];
 
   if (!taskId) {
-    console.warn("Missing task id in item event");
+    console.warn("Missing task id in item event", { requestId });
     return;
   }
 
@@ -184,12 +186,12 @@ async function handleItemEvent(event: any, user: any): Promise<void> {
   if (event.event_name === "item:updated") {
     const todoist = new TodoistClient(user.todoist_token);
     const comments = await todoist.getComments(taskId);
-    if (comments.some((c: any) => (c.content ?? "").startsWith(AI_INDICATOR))) {
+    if (comments.some((c: TodoistComment) => (c.content ?? "").startsWith(AI_INDICATOR))) {
       return;
     }
   }
 
-  await runAiForTask(taskId, user, String(event.user_id));
+  await runAiForTask(taskId, user, String(event.user_id), requestId);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +199,8 @@ async function handleItemEvent(event: any, user: any): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function webhookHandler(req: Request): Promise<Response> {
+  const requestId = crypto.randomUUID();
+
   if (req.method !== "POST") {
     return new Response(JSON.stringify({ error: "Method not allowed" }), {
       status: 405,
@@ -217,7 +221,7 @@ export async function webhookHandler(req: Request): Promise<Response> {
   // Verify HMAC immediately — before parsing JSON or querying DB
   const clientSecret = Deno.env.get("TODOIST_CLIENT_SECRET");
   if (!clientSecret) {
-    console.error("TODOIST_CLIENT_SECRET is not configured");
+    console.error("TODOIST_CLIENT_SECRET is not configured", { requestId });
     return new Response(JSON.stringify({ error: "Server misconfiguration" }), {
       status: 500,
       headers: { "Content-Type": "application/json" },
@@ -232,7 +236,7 @@ export async function webhookHandler(req: Request): Promise<Response> {
   }
 
   // Parse payload after signature is verified
-  let event: any;
+  let event: TodoistWebhookEvent;
   try {
     event = JSON.parse(rawBody);
   } catch {
@@ -277,7 +281,7 @@ export async function webhookHandler(req: Request): Promise<Response> {
   }
 
   // Idempotency check — prevent duplicate AI responses from concurrent deliveries
-  const entityId = event.event_data?.id ?? event.event_data?.item_id ?? "";
+  const entityId = event.event_data?.id ?? ("item_id" in event.event_data ? event.event_data.item_id : "") ?? "";
   const eventKey = `${userId}:${event.event_name}:${entityId}`;
   if (eventKey && entityId) {
     const { data: claimed } = await supabase.rpc("try_claim_event", { p_event_id: eventKey });
@@ -289,8 +293,8 @@ export async function webhookHandler(req: Request): Promise<Response> {
     }
   }
 
-  const decryptedUser = {
-    ...user,
+  const decryptedUser: UserConfig = {
+    ...user as UserConfig,
     todoist_token: await decrypt(user.todoist_token),
     custom_ai_api_key: await decryptIfPresent(user.custom_ai_api_key),
     custom_brave_key: await decryptIfPresent(user.custom_brave_key),
@@ -299,12 +303,13 @@ export async function webhookHandler(req: Request): Promise<Response> {
   const processPromise = (async () => {
     try {
       if (event.event_name === "note:added" || event.event_name === "note:updated") {
-        await handleNoteEvent(event, decryptedUser);
+        await handleNoteEvent(event, decryptedUser, requestId);
       } else if (event.event_name === "item:added" || event.event_name === "item:updated") {
-        await handleItemEvent(event, decryptedUser);
+        await handleItemEvent(event, decryptedUser, requestId);
       }
     } catch (error) {
       console.error("Async webhook processing failed", {
+        requestId,
         event_name: event.event_name,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -312,14 +317,14 @@ export async function webhookHandler(req: Request): Promise<Response> {
     }
   })();
 
-  const edgeRuntime = (globalThis as any).EdgeRuntime;
+  const edgeRuntime = (globalThis as Record<string, unknown>).EdgeRuntime as { waitUntil?: (p: Promise<void>) => void } | undefined;
   if (edgeRuntime?.waitUntil) {
     edgeRuntime.waitUntil(processPromise);
   } else {
-    processPromise.catch((e) => console.error("Background processing error", e));
+    processPromise.catch((e) => console.error("Background processing error", { requestId, error: e }));
   }
 
-  return new Response(JSON.stringify({ ok: true }), {
+  return new Response(JSON.stringify({ ok: true, request_id: requestId }), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });

--- a/supabase/functions/webhook/index.ts
+++ b/supabase/functions/webhook/index.ts
@@ -1,4 +1,8 @@
 import { webhookHandler } from "./handler.ts";
 import { withSentry } from "../_shared/sentry.ts";
+import { validateEnv, validateEncryptionKey } from "../_shared/env.ts";
+
+validateEnv(["TODOIST_CLIENT_SECRET", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+validateEncryptionKey();
 
 Deno.serve(withSentry(webhookHandler));


### PR DESCRIPTION
## Summary

- **Type safety (#102):** Replace all `any` types with proper interfaces (`UserConfig`, `TodoistComment`, `TodoistWebhookEvent`, `OpenAiResponse`, `AnthropicResponse`, etc.). Remove `no-explicit-any` from deno.json lint exclusions. Fix `openaiExtractContent` return type violation (`undefined as any` → proper `string | null | undefined`).
- **Env validation (#101):** Add `validateEnv()` and `validateEncryptionKey()` called at edge function startup. Catches missing/empty env vars and invalid ENCRYPTION_KEY (wrong length, bad base64) at boot instead of at runtime.
- **Request tracing (#100):** Generate a correlation `requestId` (UUID) at webhook entry, thread it through all handlers and log statements, and return it in the 200 response body for end-to-end traceability.

## Test plan

- [x] All 243 backend tests pass (`deno test`)
- [x] 12 new tests for env validation (missing vars, empty strings, whitespace, invalid base64, wrong key length)
- [x] Webhook test verifies `request_id` in response
- [x] `deno lint` passes clean (0 errors, including no-explicit-any)
- [x] Frontend lint passes

Closes #100, closes #101, closes #102

🤖 Generated with [Claude Code](https://claude.ai/code)