### PR TITLE
Add tests for AuthCallback and expand Landing page tests

### DIFF
--- a/frontend/src/pages/AuthCallback.test.tsx
+++ b/frontend/src/pages/AuthCallback.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AuthCallback from "./AuthCallback";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockSetSession = vi.fn();
+vi.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: {
+      setSession: (...args: unknown[]) => mockSetSession(...args),
+    },
+  },
+}));
+
+function renderCallback(hash = "") {
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, hash },
+    writable: true,
+  });
+  return render(
+    <MemoryRouter>
+      <AuthCallback />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// Loading state
+// ============================================================================
+
+describe("AuthCallback: loading state", () => {
+  it("shows 'Completing setup...' text", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockReturnValue(new Promise(() => {}));
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    expect(screen.getByText("Completing setup...")).toBeInTheDocument();
+  });
+
+  it("has aria-busy on main element", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockReturnValue(new Promise(() => {}));
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    expect(screen.getByRole("main")).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("has status role with aria-live for screen readers", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockReturnValue(new Promise(() => {}));
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+  });
+});
+
+// ============================================================================
+// CSRF state verification
+// ============================================================================
+
+describe("AuthCallback: CSRF state verification", () => {
+  it("redirects to /?error=state_mismatch when oauth_pending is missing", () => {
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/?error=state_mismatch");
+  });
+
+  it("removes oauth_pending from sessionStorage after reading", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockResolvedValue({ error: null });
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    expect(sessionStorage.getItem("oauth_pending")).toBeNull();
+  });
+});
+
+// ============================================================================
+// Missing tokens
+// ============================================================================
+
+describe("AuthCallback: missing tokens", () => {
+  it("redirects to /?error=missing_session when access_token is missing", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    renderCallback("#refresh_token=test-refresh");
+    expect(mockNavigate).toHaveBeenCalledWith("/?error=missing_session");
+  });
+
+  it("redirects to /?error=missing_session when refresh_token is missing", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    renderCallback("#access_token=test-access");
+    expect(mockNavigate).toHaveBeenCalledWith("/?error=missing_session");
+  });
+
+  it("redirects to /?error=missing_session when hash is empty", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    renderCallback("");
+    expect(mockNavigate).toHaveBeenCalledWith("/?error=missing_session");
+  });
+});
+
+// ============================================================================
+// Successful auth
+// ============================================================================
+
+describe("AuthCallback: successful auth", () => {
+  it("calls setSession with tokens from URL hash", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockResolvedValue({ error: null });
+    renderCallback(
+      "#access_token=my-access-tok&refresh_token=my-refresh-tok",
+    );
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: "my-access-tok",
+      refresh_token: "my-refresh-tok",
+    });
+  });
+
+  it("navigates to /settings on successful session", async () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockResolvedValue({ error: null });
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+    await vi.waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/settings"),
+    );
+  });
+});
+
+// ============================================================================
+// Session errors
+// ============================================================================
+
+describe("AuthCallback: session errors", () => {
+  it("navigates to /?error=session_failed when setSession returns error", async () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockResolvedValue({
+      error: new Error("Invalid token"),
+    });
+    renderCallback(
+      "#access_token=bad-token&refresh_token=bad-refresh",
+    );
+    await vi.waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/?error=session_failed"),
+    );
+  });
+});
+
+// ============================================================================
+// Timeout
+// ============================================================================
+
+describe("AuthCallback: timeout", () => {
+  it("navigates to /?error=timeout after 10 seconds", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockReturnValue(new Promise(() => {})); // never resolves
+    renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+
+    vi.advanceTimersByTime(10_000);
+    expect(mockNavigate).toHaveBeenCalledWith("/?error=timeout");
+  });
+
+  it("clears timeout on component unmount", () => {
+    sessionStorage.setItem("oauth_pending", "true");
+    mockSetSession.mockReturnValue(new Promise(() => {}));
+    const { unmount } = renderCallback(
+      "#access_token=test-access&refresh_token=test-refresh",
+    );
+
+    unmount();
+    vi.advanceTimersByTime(10_000);
+    // Timeout should have been cleared on unmount
+    expect(mockNavigate).not.toHaveBeenCalledWith("/?error=timeout");
+  });
+});

--- a/frontend/src/pages/Landing.test.tsx
+++ b/frontend/src/pages/Landing.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import Landing from "./Landing";
@@ -18,7 +19,12 @@ vi.mock("../lib/supabase", () => ({
   },
 }));
 
-function renderLanding() {
+function renderLanding(searchParams = "") {
+  // Set window.location.search before rendering
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, search: searchParams, href: "" },
+    writable: true,
+  });
   return render(
     <MemoryRouter>
       <Landing />
@@ -29,34 +35,39 @@ function renderLanding() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetSession.mockResolvedValue({ data: { session: null } });
+  sessionStorage.clear();
 });
 
-describe("Landing", () => {
+// ============================================================================
+// Rendering
+// ============================================================================
+
+describe("Landing: rendering", () => {
   it("renders heading and connect button", () => {
     renderLanding();
     expect(screen.getByText("Todoist AI Agent")).toBeInTheDocument();
     expect(screen.getByText("Connect Todoist")).toBeInTheDocument();
   });
 
-  it("has main landmark with aria-labelledby", () => {
+  it("renders feature list items", () => {
     renderLanding();
-    const main = screen.getByRole("main");
-    expect(main).toHaveAttribute("aria-labelledby", "landing-heading");
+    expect(screen.getByText(/Comment/)).toBeInTheDocument();
+    expect(screen.getByText(/Web search/)).toBeInTheDocument();
+    expect(screen.getByText(/Bring your own AI key/)).toBeInTheDocument();
   });
 
-  it("feature list has aria-label", () => {
+  it("renders GitHub links", () => {
     renderLanding();
-    expect(screen.getByRole("list", { name: "Features" })).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("GitHub issue")).toBeInTheDocument();
   });
+});
 
-  it("emoji icons are hidden from screen readers", () => {
-    renderLanding();
-    const emojis = screen.getAllByText(/💬|🔍|🔑/);
-    emojis.forEach((el) => {
-      expect(el).toHaveAttribute("aria-hidden", "true");
-    });
-  });
+// ============================================================================
+// Session redirect
+// ============================================================================
 
+describe("Landing: session redirect", () => {
   it("redirects to /settings if session exists", async () => {
     mockGetSession.mockResolvedValue({
       data: { session: { access_token: "tok" } },
@@ -65,5 +76,99 @@ describe("Landing", () => {
     await vi.waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/settings"),
     );
+  });
+
+  it("does not redirect when no session", async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    renderLanding();
+    // Wait for the getSession promise to resolve
+    await vi.waitFor(() => expect(mockGetSession).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Connect button (OAuth initiation)
+// ============================================================================
+
+describe("Landing: connect button", () => {
+  it("sets oauth_pending in sessionStorage and redirects on click", async () => {
+    const user = userEvent.setup();
+    renderLanding();
+
+    await user.click(screen.getByText("Connect Todoist"));
+
+    expect(sessionStorage.getItem("oauth_pending")).toBe("true");
+  });
+
+  it("shows Redirecting... and disables button after click", async () => {
+    const user = userEvent.setup();
+    renderLanding();
+
+    await user.click(screen.getByText("Connect Todoist"));
+
+    expect(screen.getByText("Redirecting...")).toBeInTheDocument();
+    expect(screen.getByText("Redirecting...").closest("button")).toBeDisabled();
+  });
+
+  it("button has aria-busy while connecting", async () => {
+    const user = userEvent.setup();
+    renderLanding();
+
+    await user.click(screen.getByText("Connect Todoist"));
+
+    expect(
+      screen.getByText("Redirecting...").closest("button"),
+    ).toHaveAttribute("aria-busy", "true");
+  });
+});
+
+// ============================================================================
+// Error display
+// ============================================================================
+
+describe("Landing: error display", () => {
+  it("shows error message when ?error param is present", () => {
+    renderLanding("?error=auth_failed");
+    expect(
+      screen.getByText("Authentication failed. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("error message has role=alert", () => {
+    renderLanding("?error=auth_failed");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("does not show error when no ?error param", () => {
+    renderLanding();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// Accessibility
+// ============================================================================
+
+describe("Landing: accessibility", () => {
+  it("has main landmark with aria-labelledby", () => {
+    renderLanding();
+    const main = screen.getByRole("main");
+    expect(main).toHaveAttribute("aria-labelledby", "landing-heading");
+  });
+
+  it("feature list has aria-label", () => {
+    renderLanding();
+    expect(
+      screen.getByRole("list", { name: "Features" }),
+    ).toBeInTheDocument();
+  });
+
+  it("emoji icons are hidden from screen readers", () => {
+    renderLanding();
+    const emojis = screen.getAllByText(/💬|🔍|🔑/);
+    emojis.forEach((el) => {
+      expect(el).toHaveAttribute("aria-hidden", "true");
+    });
   });
 });


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- List the key changes made -->

-

## Test Plan

<!-- How was this tested? -->

- [ ] Deno tests pass (`npm test`)
- [ ] Frontend lint passes (`cd frontend && npm run lint`)
- [ ] Frontend builds (`npm run frontend:build`)
- [ ] Manually tested locally (if applicable)
