### PR TITLE
Fix release-please PR blocked by missing CI checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,14 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr_number.outputs.value }}
+      pr_sha: ${{ steps.pr_sha.outputs.value }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -18,11 +22,106 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Auto-merge Release PR
+      - name: Export PR metadata
+        id: pr_number
+        if: steps.release.outputs.pr
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: echo "value=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+
+      - name: Export PR head SHA
+        id: pr_sha
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --auto
+          SHA=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "value=$SHA" >> "$GITHUB_OUTPUT"
+
+  # GITHUB_TOKEN pushes don't trigger pull_request workflows on release-please
+  # PRs. Run CI here and report status checks on the PR head SHA so branch
+  # protection required checks pass.
+  frontend:
+    needs: release
+    if: needs.release.outputs.pr_number
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.pr_sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: cd frontend && npm ci
+
+      - name: Lint
+        run: cd frontend && npm run lint
+
+      - name: Test
+        run: cd frontend && npm test
+
+      - name: Build
+        run: cd frontend && npm run build
+
+      - name: Report status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.release.outputs.pr_sha }}
+          STATUS: ${{ job.status == 'success' && 'success' || 'failure' }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state="$STATUS" \
+            -f context="frontend" \
+            -f description="Release CI" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+  deno-tests:
+    needs: release
+    if: needs.release.outputs.pr_number
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.pr_sha }}
+
+      - uses: denoland/setup-deno@v2
+
+      - name: Lint
+        run: deno lint supabase/functions/
+
+      - name: Test
+        run: deno test supabase/functions/tests/ --no-check --allow-env --allow-read
+
+      - name: Report status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.release.outputs.pr_sha }}
+          STATUS: ${{ job.status == 'success' && 'success' || 'failure' }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state="$STATUS" \
+            -f context="deno-tests" \
+            -f description="Release CI" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+  auto-merge:
+    needs: [release, frontend, deno-tests]
+    if: needs.release.outputs.pr_number
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.release.outputs.pr_number }}
+        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --auto


### PR DESCRIPTION
## Summary

- Run CI jobs (`frontend`, `deno-tests`) inline in the Release workflow when a release-please PR exists
- Use the GitHub Statuses API to report check results on the PR's head SHA, satisfying branch protection
- Enable auto-merge after CI passes

Fixes #161

## Context

`GITHUB_TOKEN` pushes don't trigger `pull_request` workflows ([GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)). This means release-please PRs (like #84) never get the required `frontend` and `deno-tests` status checks, permanently blocking them.

## Test plan

- [ ] Merge this PR into main
- [ ] Verify the Release workflow runs and reports `frontend` + `deno-tests` statuses on PR #84
- [ ] Verify PR #84 auto-merges once checks pass