### PR TITLE
Add one-click reset buttons for AI and Search settings

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -540,6 +540,7 @@ export default function Settings() {
                 type="button"
                 onClick={async () => {
                   testAbortRef.current?.abort();
+                  setTesting(false);
                   setTestResult(null);
                   const { data: { session } } = await supabase.auth.getSession();
                   if (!session) return;


### PR DESCRIPTION
## Summary

Closes #172

- Replace small "Clear saved key" text links with prominent **"Reset AI Settings"** and **"Reset Search Key"** buttons
- "Reset AI Settings" clears base URL, API key, and model in one click (previously only the API key could be cleared individually)
- Both buttons check `res.ok` and show error messages on failure
- AI reset aborts any in-flight test connection and clears stale test results before making the request
- Test result display re-gated behind `aiBaseUrl && aiApiKey && aiModel` to prevent stale results showing when fields are cleared

## Test plan

- [ ] Verify "Reset AI Settings" button appears when any AI setting is configured
- [ ] Verify it clears all three fields (base URL, key, model) and the server-side values
- [ ] Verify "Reset Search Key" button appears when a Brave key is saved
- [ ] Verify error message appears if reset request fails
- [ ] Verify test result disappears when fields are cleared
- [ ] Run frontend tests: `cd frontend && npm test`
- [ ] Run frontend build: `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.ai/code)