### PR TITLE
Fix: AI doesn't see images in comments or task descriptions

### DIFF
--- a/supabase/functions/_shared/messages.ts
+++ b/supabase/functions/_shared/messages.ts
@@ -33,7 +33,8 @@ export function commentsToMessages(
     if (comment.id === progressCommentId) continue;
 
     const content: string = comment.content ?? "";
-    if (!content.trim()) continue;
+    const hasImageAttachment = !!comment.file_attachment?.file_type?.startsWith("image/");
+    if (!content.trim() && !hasImageAttachment) continue;
 
     if (content.startsWith(AI_INDICATOR)) {
       if (content === PROGRESS_INDICATOR) continue;
@@ -46,8 +47,8 @@ export function commentsToMessages(
       continue;
     } else {
       const stripped = content.replace(triggerRegex, "").replace(/\s+/g, " ").trim();
-      if (stripped) {
-        messages.push({ role: "user", content: stripped });
+      if (stripped || hasImageAttachment) {
+        messages.push({ role: "user", content: stripped || "[image]" });
         commentIds.push(comment.id);
       }
     }

--- a/supabase/functions/_shared/types.ts
+++ b/supabase/functions/_shared/types.ts
@@ -3,9 +3,11 @@
 // ---------------------------------------------------------------------------
 
 export interface TodoistFileAttachment {
-  resource_type: string;
-  file_url: string;
   file_type: string;
+  file_name: string;
+  file_url: string;
+  file_size?: number;
+  upload_state?: string;
 }
 
 export interface TodoistComment {

--- a/supabase/functions/_shared/validation.ts
+++ b/supabase/functions/_shared/validation.ts
@@ -112,6 +112,31 @@ export function validateSettings(
   return errors;
 }
 
+/** Extract image URLs from markdown ![alt](url) syntax.
+ *  Handles URLs with balanced parentheses (e.g. `path(1).png`). */
+export function extractMarkdownImageUrls(text: string): string[] {
+  const regex = /!\[[^\]]*\]\(([^()\s]+(?:\([^)]*\)[^()\s]*)*)\)/g;
+  const urls: string[] = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    urls.push(match[1]);
+  }
+  return urls;
+}
+
+/** Guess media type from a URL's file extension. */
+export function guessMediaType(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const ext = pathname.split(".").pop()?.toLowerCase();
+    if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+    if (ext === "png") return "image/png";
+    if (ext === "gif") return "image/gif";
+    if (ext === "webp") return "image/webp";
+  } catch { /* ignore */ }
+  return "image/png";
+}
+
 const ALLOWED_IMAGE_TYPES = new Set([
   "image/png",
   "image/jpeg",

--- a/supabase/functions/tests/messages.test.ts
+++ b/supabase/functions/tests/messages.test.ts
@@ -149,6 +149,91 @@ Deno.test("empty comments array: returns empty", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Image attachment handling
+// ---------------------------------------------------------------------------
+
+Deno.test("image-only comment (no text): included as [image] placeholder", () => {
+  const comments = [{
+    id: "1",
+    content: "",
+    file_attachment: { file_type: "image/png", file_name: "img.png", file_url: "https://files.todoist.com/img.png" },
+  }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, [{ role: "user", content: "[image]" }]);
+  assertEquals(result.commentIds, ["1"]);
+});
+
+Deno.test("comment with text and attachment: text content used, ID tracked", () => {
+  const comments = [{
+    id: "1",
+    content: "@ai what is this?",
+    file_attachment: { file_type: "image/png", file_name: "img.png", file_url: "https://files.todoist.com/img.png" },
+  }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, [{ role: "user", content: "what is this?" }]);
+  assertEquals(result.commentIds, ["1"]);
+});
+
+Deno.test("image-only comment with null content: included as [image]", () => {
+  const comments = [{
+    id: "1",
+    content: null,
+    file_attachment: { file_type: "image/png", file_name: "img.png", file_url: "https://files.todoist.com/img.png" },
+  }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, [{ role: "user", content: "[image]" }]);
+  assertEquals(result.commentIds, ["1"]);
+});
+
+Deno.test("comment with only trigger word + attachment: included as [image]", () => {
+  const comments = [{
+    id: "1",
+    content: "@ai",
+    file_attachment: { file_type: "image/png", file_name: "img.png", file_url: "https://files.todoist.com/img.png" },
+  }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, [{ role: "user", content: "[image]" }]);
+  assertEquals(result.commentIds, ["1"]);
+});
+
+Deno.test("empty comment without attachment: still skipped", () => {
+  const comments = [{ id: "1", content: "" }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, []);
+  assertEquals(result.commentIds, []);
+});
+
+Deno.test("non-image attachment (PDF) without text: skipped", () => {
+  const comments = [{
+    id: "1",
+    content: "",
+    file_attachment: { file_type: "application/pdf", file_name: "doc.pdf", file_url: "https://files.todoist.com/doc.pdf" },
+  }];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, []);
+  assertEquals(result.commentIds, []);
+});
+
+Deno.test("multi-turn with image-only comment in middle: preserved in order", () => {
+  const comments = [
+    { id: "1", content: "@ai help" },
+    { id: "2", content: `${AI_INDICATOR}\n\nSure, send me the image.` },
+    {
+      id: "3",
+      content: "",
+      file_attachment: { file_type: "image/png", file_name: "img.png", file_url: "https://files.todoist.com/img.png" },
+    },
+  ];
+  const result = commentsToMessages(comments, "@ai", "none");
+  assertEquals(result.messages, [
+    { role: "user", content: "help" },
+    { role: "assistant", content: "Sure, send me the image." },
+    { role: "user", content: "[image]" },
+  ]);
+  assertEquals(result.commentIds, ["1", "2", "3"]);
+});
+
+// ---------------------------------------------------------------------------
 // normalizeBaseUrl — covers the trailing-space production bug
 // ---------------------------------------------------------------------------
 

--- a/supabase/functions/tests/validation.test.ts
+++ b/supabase/functions/tests/validation.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { validateSettings, isPrivateHostname, sanitizeImageMediaType } from "../_shared/validation.ts";
+import { validateSettings, isPrivateHostname, sanitizeImageMediaType, extractMarkdownImageUrls, guessMediaType } from "../_shared/validation.ts";
 
 // -- max_messages --
 
@@ -301,4 +301,77 @@ Deno.test("sanitizeImageMediaType: handles undefined", () => {
 
 Deno.test("sanitizeImageMediaType: handles empty string", () => {
   assertEquals(sanitizeImageMediaType(""), "image/png");
+});
+
+// -- extractMarkdownImageUrls --
+
+Deno.test("extractMarkdownImageUrls: extracts single image URL", () => {
+  assertEquals(
+    extractMarkdownImageUrls("Check this: ![screenshot](https://files.todoist.com/img.png)"),
+    ["https://files.todoist.com/img.png"]
+  );
+});
+
+Deno.test("extractMarkdownImageUrls: extracts multiple image URLs", () => {
+  const text = "![a](https://files.todoist.com/a.png) and ![b](https://files.todoist.com/b.jpg)";
+  assertEquals(extractMarkdownImageUrls(text), [
+    "https://files.todoist.com/a.png",
+    "https://files.todoist.com/b.jpg",
+  ]);
+});
+
+Deno.test("extractMarkdownImageUrls: empty alt text", () => {
+  assertEquals(
+    extractMarkdownImageUrls("![](https://files.todoist.com/img.png)"),
+    ["https://files.todoist.com/img.png"]
+  );
+});
+
+Deno.test("extractMarkdownImageUrls: no images returns empty", () => {
+  assertEquals(extractMarkdownImageUrls("Just some text"), []);
+});
+
+Deno.test("extractMarkdownImageUrls: ignores regular links", () => {
+  assertEquals(extractMarkdownImageUrls("[click here](https://example.com)"), []);
+});
+
+Deno.test("extractMarkdownImageUrls: empty string returns empty", () => {
+  assertEquals(extractMarkdownImageUrls(""), []);
+});
+
+Deno.test("extractMarkdownImageUrls: handles URLs with parentheses", () => {
+  assertEquals(
+    extractMarkdownImageUrls("![img](https://example.com/path(1).png)"),
+    ["https://example.com/path(1).png"]
+  );
+});
+
+// -- guessMediaType --
+
+Deno.test("guessMediaType: detects png", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/img.png"), "image/png");
+});
+
+Deno.test("guessMediaType: detects jpeg", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/photo.jpeg"), "image/jpeg");
+});
+
+Deno.test("guessMediaType: detects jpg", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/photo.jpg"), "image/jpeg");
+});
+
+Deno.test("guessMediaType: detects gif", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/anim.gif"), "image/gif");
+});
+
+Deno.test("guessMediaType: detects webp", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/img.webp"), "image/webp");
+});
+
+Deno.test("guessMediaType: defaults to png for unknown extension", () => {
+  assertEquals(guessMediaType("https://files.todoist.com/file.bmp"), "image/png");
+});
+
+Deno.test("guessMediaType: defaults to png for invalid URL", () => {
+  assertEquals(guessMediaType("not-a-url"), "image/png");
 });

--- a/supabase/functions/webhook/handler.ts
+++ b/supabase/functions/webhook/handler.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_AI_MODEL,
   DEFAULT_MAX_MESSAGES,
   MAX_WEBHOOK_BODY_BYTES,
+  MAX_IMAGE_SIZE_BYTES,
 } from "../_shared/constants.ts";
 import {
   getRateLimitConfig,
@@ -15,7 +16,7 @@ import {
 import { commentsToMessages, normalizeModel } from "../_shared/messages.ts";
 import { captureException } from "../_shared/sentry.ts";
 import { uint8ToBase64, verifyHmac, decrypt, decryptIfPresent } from "../_shared/crypto.ts";
-import { sanitizeImageMediaType, isPrivateHostname } from "../_shared/validation.ts";
+import { sanitizeImageMediaType, isPrivateHostname, extractMarkdownImageUrls, guessMediaType } from "../_shared/validation.ts";
 import type { TodoistComment, TodoistWebhookEvent, UserConfig } from "../_shared/types.ts";
 
 // ---------------------------------------------------------------------------
@@ -83,7 +84,7 @@ async function runAiForTask(
     // Only download images from comments within the message window (#96)
     const imageComments = comments.filter(
       (c: TodoistComment) =>
-        c.file_attachment?.resource_type === "image" &&
+        c.file_attachment?.file_type?.startsWith("image/") &&
         windowCommentIds.has(c.id)
     );
     const imageResults = await Promise.allSettled(
@@ -110,6 +111,52 @@ async function runAiForTask(
     const images = imageResults
       .filter((r): r is PromiseFulfilledResult<{ data: string; mediaType: string }> => r.status === "fulfilled")
       .map((r) => r.value);
+
+    // Download images embedded in task description via markdown syntax (cap at 5 to prevent DoS)
+    if (task.description) {
+      const descImageUrls = extractMarkdownImageUrls(task.description).slice(0, 5);
+      if (descImageUrls.length > 0) {
+        const descResults = await Promise.allSettled(
+          descImageUrls.map(async (url: string) => {
+            // Validate URL: HTTPS only, no private/internal hosts (SSRF prevention)
+            try {
+              const parsed = new URL(url);
+              if (parsed.protocol !== "https:" || isPrivateHostname(parsed.hostname)) return null;
+            } catch {
+              return null;
+            }
+            // Plain fetch without auth — description images may be external
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+            const contentLength = res.headers.get("content-length");
+            if (contentLength && Number(contentLength) > MAX_IMAGE_SIZE_BYTES) {
+              throw new Error(`File exceeds maximum size of ${MAX_IMAGE_SIZE_BYTES / (1024 * 1024)} MB`);
+            }
+            const bytes = new Uint8Array(await res.arrayBuffer());
+            if (bytes.byteLength > MAX_IMAGE_SIZE_BYTES) {
+              throw new Error(`File exceeds maximum size of ${MAX_IMAGE_SIZE_BYTES / (1024 * 1024)} MB`);
+            }
+            return { data: uint8ToBase64(bytes), mediaType: sanitizeImageMediaType(guessMediaType(url)) };
+          })
+        );
+        const descRejected = descResults.filter((r) => r.status === "rejected");
+        if (descRejected.length > 0) {
+          console.warn("Some description image downloads failed", {
+            requestId,
+            taskId,
+            failedCount: descRejected.length,
+            errors: descRejected.map((r) =>
+              (r as PromiseRejectedResult).reason instanceof Error
+                ? (r as PromiseRejectedResult).reason.message
+                : String((r as PromiseRejectedResult).reason)
+            ),
+          });
+        }
+        for (const r of descResults) {
+          if (r.status === "fulfilled" && r.value) images.push(r.value);
+        }
+      }
+    }
 
     const aiConfig = {
       baseUrl: (


### PR DESCRIPTION
## Summary

Closes #176

- **Root cause**: Code checked non-existent `resource_type` field on Todoist file attachments — the actual API v1 field is `file_type` (MIME type). Images were never downloaded.
- **Image-only comments** (no text, just an image) were silently dropped by `commentsToMessages()`. Now included as `[image]` placeholder for image file types only.
- **Description images**: Extracts markdown `![](url)` from task descriptions and downloads them via plain `fetch` (no auth header since they may be external URLs).
- **Security**: HTTPS-only, `isPrivateHostname` SSRF check, 4MB size limit, capped at 5 description images.

### Changes
| File | Change |
|------|--------|
| `types.ts` | Updated `TodoistFileAttachment` to match actual API (`file_type`, `file_name`, `file_url`, `file_size?`, `upload_state?`) |
| `handler.ts` | Changed filter from `resource_type === "image"` to `file_type?.startsWith("image/")`. Added description image extraction with SSRF protection |
| `messages.ts` | Image-only comments included as `[image]` (only for `image/*` MIME types) |
| `validation.ts` | Added `extractMarkdownImageUrls()` and `guessMediaType()` helpers |
| `messages.test.ts` | 7 new tests for image attachment handling |
| `validation.test.ts` | 14 new tests for markdown extraction and media type guessing |

## Test plan

- [x] All 317 backend tests pass
- [x] Deno lint passes
- [ ] Verify with real Todoist comment containing text + image → AI sees the image
- [ ] Verify image-only comment (no text) is included in conversation context
- [ ] Verify task description with markdown image is downloaded and sent to AI
- [ ] Verify non-HTTPS and private IP description image URLs are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)