### PR TITLE
Add e2e tests for image handling in webhook flow

### DIFF
--- a/supabase/functions/tests/webhook.test.ts
+++ b/supabase/functions/tests/webhook.test.ts
@@ -764,11 +764,16 @@ function mockFullFlowWithImages(options: {
     ? "https://api.anthropic.com/v1"
     : "https://api.openai.com/v1";
 
+  // Save original env vars so restore() can clean up
+  const prevBaseUrl = Deno.env.get("DEFAULT_AI_BASE_URL");
+  const prevApiKey = Deno.env.get("DEFAULT_AI_API_KEY");
+  const prevModel = Deno.env.get("DEFAULT_AI_MODEL");
+
   Deno.env.set("DEFAULT_AI_BASE_URL", aiBaseUrl);
   Deno.env.set("DEFAULT_AI_API_KEY", "test-key");
   Deno.env.set("DEFAULT_AI_MODEL", useAnthropic ? "claude-3-5-sonnet" : "gpt-4o-mini");
 
-  return mockFetch((url, init) => {
+  const restoreFetch = mockFetch((url, init) => {
     // Supabase
     if (url.includes("/rest/v1/users_config") && init?.method !== "POST" && !url.includes("rpc")) {
       return new Response(JSON.stringify(mockUserConfig()), {
@@ -853,6 +858,17 @@ function mockFullFlowWithImages(options: {
       status: 200, headers: { "Content-Type": "image/png" },
     });
   });
+
+  return () => {
+    restoreFetch();
+    // Restore env vars to prevent leakage between tests
+    if (prevBaseUrl !== undefined) Deno.env.set("DEFAULT_AI_BASE_URL", prevBaseUrl);
+    else Deno.env.delete("DEFAULT_AI_BASE_URL");
+    if (prevApiKey !== undefined) Deno.env.set("DEFAULT_AI_API_KEY", prevApiKey);
+    else Deno.env.delete("DEFAULT_AI_API_KEY");
+    if (prevModel !== undefined) Deno.env.set("DEFAULT_AI_MODEL", prevModel);
+    else Deno.env.delete("DEFAULT_AI_MODEL");
+  };
 }
 
 // -- A. Comment Image Attachments --


### PR DESCRIPTION
Closes #179

## Summary
- Add 9 e2e-style tests to `webhook.test.ts` covering image handling in the webhook → AI pipeline
- Add reusable `mockFullFlowWithImages` helper that supports configurable comments, task descriptions, AI request capture, image download failure simulation, and Anthropic/OpenAI provider switching

### Test scenarios

**Comment Image Attachments (A):**
- Text + image attachment → base64 `image_url` in AI request
- Image-only comment (trigger word only) → `[image]` text + image data
- Multiple comments with images → all attached to last user message
- Download failure → AI processes gracefully without images
- Non-image attachment (PDF) → ignored

**Task Description Images (B):**
- Markdown image → downloaded and included in AI request
- Private IP image → SSRF-rejected, AI continues without it
- HTTP protocol image → rejected, AI continues without it

**Anthropic Provider (C):**
- Image converted to `{ type: "image", source: { type: "base64" } }` format

## Test plan
- [x] All 31 webhook tests pass (22 existing + 9 new)
- [x] Full test suite passes (326 tests)
- [x] `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)