### PR TITLE
feat: add text-based file attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sequenceDiagram
 | **Rate limiting** | Per-user webhook and settings rate limits with account blocking |
 | **Bring your own key** | Supports Anthropic (Claude) and any OpenAI-compatible provider, with key validation before save |
 | **Image support** | Attach images to comments for multimodal AI analysis |
-| **PDF document support** | Attach PDF files to comments — processed natively by Anthropic provider |
+| **File attachments** | Attach PDFs (Anthropic native) or text-based files (.txt, .md, .csv, .json, .py, .sh, etc.) for AI analysis |
 | **Data isolation** | Row Level Security ensures complete tenant separation |
 | **Error tracking** | Optional Sentry integration for monitoring |
 | **Accessible UI** | ARIA labels, focus management, keyboard navigation, screen reader support |
@@ -321,7 +321,7 @@ deno lint supabase/functions/   # Deno lint for Edge Functions
 | **Code scanning** | CodeQL analysis for security vulnerabilities |
 | **Dependency scanning** | Automated npm audit + Dependabot |
 | **Rate limiting** | Per-user webhook and settings rate limits |
-| **Attachment limits** | 4 MB max per image or document attachment |
+| **Attachment limits** | 4 MB max per image or document attachment, 50k char cap for text file content |
 | **URL fetch limits** | 2 MB download cap, 50k char output, 15s timeout, no redirects |
 
 ## License

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -1,6 +1,6 @@
 import { braveSearch } from "./search.ts";
 import { fetchUrl } from "./fetch-url.ts";
-import { MAX_TOOL_ROUNDS, DEFAULT_MAX_TOKENS, MAX_AI_RESPONSE_BYTES, FALLBACK_STATUS_CODES } from "./constants.ts";
+import { MAX_TOOL_ROUNDS, DEFAULT_MAX_TOKENS, MAX_AI_RESPONSE_BYTES, FALLBACK_STATUS_CODES, MAX_TEXT_FILE_CHARS } from "./constants.ts";
 import * as Sentry from "@sentry/deno"; // startSpan is a no-op when Sentry is not initialized (no DSN set)
 import type {
   OpenAiResponse,
@@ -23,6 +23,7 @@ export interface DocumentAttachment {
   data: string;
   mediaType: string;
   fileName: string;
+  textContent?: string;
 }
 
 export interface AiConfig {
@@ -43,7 +44,7 @@ const SYSTEM_PROMPT = [
   "You help solve tasks by reasoning and providing clear, actionable answers.",
   "You can search the web when you need current information.",
   "You can fetch and read web pages when a user shares a URL or when you need content from a specific page.",
-  "Users may attach files (like PDFs) to their comments — you can read and analyze their contents.",
+  "Users may attach files to their comments — you can read and analyze PDFs and text-based files (.txt, .md, .csv, .json, .py, .ts, .sh, etc.).",
   "Respond concisely — your reply will be posted as a Todoist comment.",
 ].join("\n");
 
@@ -169,8 +170,17 @@ export function buildMessages(
       }
       if (documents) {
         for (const doc of documents) {
-          if (doc.data) {
-            // Supported document with content — will be converted per-provider
+          if (doc.textContent !== undefined) {
+            // Text file — inject as plain text, works with all providers
+            const truncated = doc.textContent.length > MAX_TEXT_FILE_CHARS
+              ? doc.textContent.slice(0, MAX_TEXT_FILE_CHARS) + "\n\n[Content truncated]"
+              : doc.textContent;
+            parts.push({
+              type: "text",
+              text: `[File: ${doc.fileName}]\n${truncated}`,
+            });
+          } else if (doc.data) {
+            // PDF document with content — will be converted per-provider
             parts.push({
               type: "document_attachment",
               file_name: doc.fileName,
@@ -178,10 +188,10 @@ export function buildMessages(
               data: doc.data,
             });
           } else {
-            // Unsupported file type — text placeholder for all providers
+            // Unsupported binary file — text placeholder for all providers
             parts.push({
               type: "text",
-              text: `[Attached file: ${doc.fileName} — only PDF files are supported for AI processing]`,
+              text: `[Attached file: ${doc.fileName} — only PDF and text-based files are supported for AI processing]`,
             });
           }
         }

--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -17,6 +17,25 @@ export const DEFAULT_MAX_TOKENS = 2048;
 
 export const MAX_IMAGE_SIZE_BYTES = 4 * 1024 * 1024; // 4 MB (also applies to document downloads via downloadFile)
 export const SUPPORTED_DOCUMENT_TYPES = new Set(["application/pdf"]);
+export const MAX_TEXT_FILE_CHARS = 50_000;
+export const SUPPORTED_TEXT_MIME_TYPES = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "text/html",
+  "text/xml",
+  "text/x-python",
+  "text/x-sh",
+  "text/x-shellscript",
+  "application/json",
+  "application/xml",
+  "application/x-yaml",
+  "application/x-sh",
+  "application/javascript",
+  "application/typescript",
+  "application/sql",
+  "application/toml",
+]);
 export const TODOIST_API_TIMEOUT_MS = 30_000; // 30 seconds
 
 export const RETRY_MAX_RETRIES = 2;

--- a/supabase/functions/_shared/validation.ts
+++ b/supabase/functions/_shared/validation.ts
@@ -157,3 +157,23 @@ export function sanitizeDocumentMediaType(fileType: string | undefined): string 
   if (fileType && ALLOWED_DOCUMENT_TYPES.has(fileType)) return fileType;
   return "application/pdf";
 }
+
+import { SUPPORTED_TEXT_MIME_TYPES } from "./constants.ts";
+
+const TEXT_FILE_EXTENSIONS = new Set([
+  "txt", "md", "markdown", "csv", "json", "jsonl", "xml", "yaml", "yml",
+  "toml", "ini", "cfg", "conf", "env", "log", "tsv",
+  "sh", "bash", "zsh", "py", "js", "ts", "jsx", "tsx",
+  "html", "htm", "css", "sql",
+  "rs", "go", "rb", "php", "java", "c", "cpp", "h", "hpp",
+  "swift", "kt", "cs", "r",
+]);
+
+/** Returns true if the file should be treated as a UTF-8 text file. */
+export function isTextFile(mimeType: string | undefined, fileName: string | undefined | null): boolean {
+  if (mimeType && SUPPORTED_TEXT_MIME_TYPES.has(mimeType)) return true;
+  if (mimeType?.startsWith("text/")) return true;
+  if (!fileName) return false;
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+  return TEXT_FILE_EXTENSIONS.has(ext);
+}

--- a/supabase/functions/tests/ai.test.ts
+++ b/supabase/functions/tests/ai.test.ts
@@ -177,7 +177,62 @@ Deno.test("buildMessages: unsupported document (empty data) becomes text placeho
   assertEquals(Array.isArray(lastUserMsg.content), true);
   assertEquals(lastUserMsg.content[1], {
     type: "text",
-    text: "[Attached file: data.xls — only PDF files are supported for AI processing]",
+    text: "[Attached file: data.xls — only PDF and text-based files are supported for AI processing]",
+  });
+});
+
+Deno.test("buildMessages: text file with textContent becomes text block with [File: name] prefix", () => {
+  const messages = [{ role: "user" as const, content: "review this" }];
+  const docs = [{ data: "", mediaType: "text/plain", fileName: "notes.txt", textContent: "Hello world" }];
+  const result = buildMessages("Task", undefined, messages, undefined, null, docs);
+
+  const lastUserMsg = result[result.length - 1];
+  assertEquals(Array.isArray(lastUserMsg.content), true);
+  assertEquals(lastUserMsg.content[1], {
+    type: "text",
+    text: "[File: notes.txt]\nHello world",
+  });
+});
+
+Deno.test("buildMessages: text file truncated at 50k chars", () => {
+  const messages = [{ role: "user" as const, content: "analyze" }];
+  const longContent = "x".repeat(60_000);
+  const docs = [{ data: "", mediaType: "text/plain", fileName: "big.log", textContent: longContent }];
+  const result = buildMessages("Task", undefined, messages, undefined, null, docs);
+
+  const lastUserMsg = result[result.length - 1];
+  const textPart = lastUserMsg.content[1];
+  assertEquals(textPart.type, "text");
+  assertEquals(textPart.text.includes("[Content truncated]"), true);
+  // 50k chars + prefix + truncation suffix
+  assertEquals(textPart.text.length < 60_000, true);
+});
+
+Deno.test("buildMessages: text file + PDF combined on last user message", () => {
+  const messages = [{ role: "user" as const, content: "compare" }];
+  const docs = [
+    { data: "", mediaType: "text/plain", fileName: "notes.txt", textContent: "some text" },
+    { data: "pdfdata", mediaType: "application/pdf", fileName: "report.pdf" },
+  ];
+  const result = buildMessages("Task", undefined, messages, undefined, null, docs);
+
+  const lastUserMsg = result[result.length - 1];
+  assertEquals(Array.isArray(lastUserMsg.content), true);
+  assertEquals(lastUserMsg.content.length, 3); // text + text_file + pdf_doc
+  assertEquals(lastUserMsg.content[1].type, "text"); // text file
+  assertEquals(lastUserMsg.content[1].text, "[File: notes.txt]\nsome text");
+  assertEquals(lastUserMsg.content[2].type, "document_attachment"); // PDF
+});
+
+Deno.test("buildMessages: empty textContent string is treated as text file (not unsupported)", () => {
+  const messages = [{ role: "user" as const, content: "check" }];
+  const docs = [{ data: "", mediaType: "text/plain", fileName: "empty.txt", textContent: "" }];
+  const result = buildMessages("Task", undefined, messages, undefined, null, docs);
+
+  const lastUserMsg = result[result.length - 1];
+  assertEquals(lastUserMsg.content[1], {
+    type: "text",
+    text: "[File: empty.txt]\n",
   });
 });
 

--- a/supabase/functions/tests/validation.test.ts
+++ b/supabase/functions/tests/validation.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { validateSettings, isPrivateHostname, sanitizeImageMediaType, extractMarkdownImageUrls, guessMediaType } from "../_shared/validation.ts";
+import { validateSettings, isPrivateHostname, sanitizeImageMediaType, extractMarkdownImageUrls, guessMediaType, isTextFile } from "../_shared/validation.ts";
 
 // -- max_messages --
 
@@ -374,4 +374,60 @@ Deno.test("guessMediaType: defaults to png for unknown extension", () => {
 
 Deno.test("guessMediaType: defaults to png for invalid URL", () => {
   assertEquals(guessMediaType("not-a-url"), "image/png");
+});
+
+// -- isTextFile --
+
+Deno.test("isTextFile: matches by MIME type", () => {
+  assertEquals(isTextFile("text/plain", "file.bin"), true);
+  assertEquals(isTextFile("application/json", "data"), true);
+  assertEquals(isTextFile("application/javascript", "code"), true);
+  assertEquals(isTextFile("text/csv", "data"), true);
+  assertEquals(isTextFile("text/markdown", "readme"), true);
+  assertEquals(isTextFile("application/x-sh", "script"), true);
+});
+
+Deno.test("isTextFile: matches any text/* MIME type", () => {
+  assertEquals(isTextFile("text/x-custom", "file"), true);
+  assertEquals(isTextFile("text/x-python", "file"), true);
+});
+
+Deno.test("isTextFile: falls back to extension when MIME is generic", () => {
+  assertEquals(isTextFile("application/octet-stream", "script.py"), true);
+  assertEquals(isTextFile("application/octet-stream", "config.yaml"), true);
+  assertEquals(isTextFile("application/octet-stream", "install.sh"), true);
+  assertEquals(isTextFile(undefined, "notes.txt"), true);
+  assertEquals(isTextFile(undefined, "code.ts"), true);
+});
+
+Deno.test("isTextFile: rejects binary file types", () => {
+  assertEquals(isTextFile("application/pdf", "doc.pdf"), false);
+  assertEquals(isTextFile("application/vnd.ms-excel", "data.xls"), false);
+  assertEquals(isTextFile("application/zip", "archive.zip"), false);
+  assertEquals(isTextFile("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "data.xlsx"), false);
+});
+
+Deno.test("isTextFile: rejects binary extensions", () => {
+  assertEquals(isTextFile(undefined, "photo.png"), false);
+  assertEquals(isTextFile(undefined, "archive.zip"), false);
+  assertEquals(isTextFile(undefined, "doc.docx"), false);
+  assertEquals(isTextFile("application/octet-stream", "data.xlsx"), false);
+});
+
+Deno.test("isTextFile: handles no extension", () => {
+  assertEquals(isTextFile(undefined, "Makefile"), false);
+  assertEquals(isTextFile(undefined, "README"), false);
+  assertEquals(isTextFile("text/plain", "README"), true);
+});
+
+Deno.test("isTextFile: handles dotfiles", () => {
+  assertEquals(isTextFile(undefined, ".env"), true);
+  assertEquals(isTextFile(undefined, ".bashrc"), false);
+  assertEquals(isTextFile(undefined, ".gitignore"), false);
+});
+
+Deno.test("isTextFile: handles null/undefined fileName", () => {
+  assertEquals(isTextFile(undefined, null), false);
+  assertEquals(isTextFile(undefined, undefined), false);
+  assertEquals(isTextFile("text/plain", null), true);
 });

--- a/supabase/functions/tests/webhook.test.ts
+++ b/supabase/functions/tests/webhook.test.ts
@@ -757,6 +757,7 @@ function mockFullFlowWithImages(options: {
   onAiRequest?: (body: Record<string, unknown>) => void;
   failImageDownload?: boolean;
   useAnthropic?: boolean;
+  fileDownloadResponse?: Response | (() => Response);
 } = {}): () => void {
   const useAnthropic = options.useAnthropic ?? false;
   const aiHost = useAnthropic ? "api.anthropic.com" : "api.openai.com";
@@ -825,6 +826,11 @@ function mockFullFlowWithImages(options: {
     ) {
       if (options.failImageDownload) {
         return new Response("Not Found", { status: 404 });
+      }
+      if (options.fileDownloadResponse) {
+        return typeof options.fileDownloadResponse === "function"
+          ? options.fileDownloadResponse()
+          : options.fileDownloadResponse;
       }
       return new Response(MOCK_PNG_BYTES, {
         status: 200, headers: { "Content-Type": "image/png" },
@@ -1186,9 +1192,164 @@ t("document: unsupported file type (XLSX) included as text placeholder", async (
     const parts = lastUser.content as Record<string, unknown>[];
     const textParts = parts.filter((p) => p.type === "text");
     const hasPlaceholder = textParts.some((p) =>
-      (p.text as string).includes("only PDF files are supported")
+      (p.text as string).includes("only PDF and text-based files are supported")
     );
     assertEquals(hasPlaceholder, true, "Should have unsupported file placeholder text");
+  } finally {
+    restore();
+  }
+});
+
+t("document: text file (.sh) is downloaded and injected as text content", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const scriptContent = '#!/bin/bash\necho "Hello World"';
+
+  const restore = mockFullFlowWithImages({
+    commentsResponse: [
+      {
+        id: "sh-1",
+        content: "@ai Review this script",
+        posted_at: "2026-01-01T00:00:00Z",
+        file_attachment: {
+          file_type: "application/x-sh",
+          file_name: "install.sh",
+          file_url: "https://files.todoist.com/install.sh",
+        },
+      },
+    ],
+    onAiRequest: (body) => { capturedBody = body; },
+    fileDownloadResponse: () => new Response(
+      new TextEncoder().encode(scriptContent),
+      { status: 200, headers: { "Content-Type": "application/x-sh" } },
+    ),
+  });
+
+  try {
+    const payload = JSON.stringify(makePayload({
+      event_data: { id: "sh-1", content: "@ai Review this script", item_id: "task-1" },
+    }));
+    const req = await signedRequest(payload);
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert(capturedBody !== null, "AI should be called for text file");
+    const messages = (capturedBody!.messages ?? capturedBody!.choices) as Record<string, unknown>[];
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    assert(lastUser, "Should have a user message");
+    assertEquals(Array.isArray(lastUser.content), true, "Text file should produce multimodal content");
+    const parts = lastUser.content as Record<string, unknown>[];
+    const textParts = parts.filter((p) => p.type === "text");
+    const filePart = textParts.find((p) =>
+      (p.text as string).includes("[File: install.sh]")
+    );
+    assert(filePart, "Should have text part with [File: install.sh]");
+    assert((filePart!.text as string).includes(scriptContent), "Should contain the script content");
+  } finally {
+    restore();
+  }
+});
+
+t("document: text file detected by extension when MIME is octet-stream", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const pyContent = "print('hello')";
+
+  const restore = mockFullFlowWithImages({
+    commentsResponse: [
+      {
+        id: "py-1",
+        content: "@ai Check this",
+        posted_at: "2026-01-01T00:00:00Z",
+        file_attachment: {
+          file_type: "application/octet-stream",
+          file_name: "script.py",
+          file_url: "https://files.todoist.com/script.py",
+        },
+      },
+    ],
+    onAiRequest: (body) => { capturedBody = body; },
+    fileDownloadResponse: () => new Response(
+      new TextEncoder().encode(pyContent),
+      { status: 200, headers: { "Content-Type": "application/octet-stream" } },
+    ),
+  });
+
+  try {
+    const payload = JSON.stringify(makePayload({
+      event_data: { id: "py-1", content: "@ai Check this", item_id: "task-1" },
+    }));
+    const req = await signedRequest(payload);
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert(capturedBody !== null, "AI should be called");
+    const messages = (capturedBody!.messages ?? capturedBody!.choices) as Record<string, unknown>[];
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    assert(lastUser, "Should have a user message");
+    const parts = lastUser.content as Record<string, unknown>[];
+    const textParts = parts.filter((p) => p.type === "text");
+    const filePart = textParts.find((p) =>
+      (p.text as string).includes("[File: script.py]")
+    );
+    assert(filePart, "Should detect .py by extension and inject text content");
+    assert((filePart!.text as string).includes(pyContent), "Should contain the Python content");
+  } finally {
+    restore();
+  }
+});
+
+t("document: text file works with OpenAI provider (no Anthropic needed)", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const csvContent = "name,age\nAlice,30\nBob,25";
+
+  const restore = mockFullFlowWithImages({
+    commentsResponse: [
+      {
+        id: "csv-1",
+        content: "@ai Analyze this data",
+        posted_at: "2026-01-01T00:00:00Z",
+        file_attachment: {
+          file_type: "text/csv",
+          file_name: "data.csv",
+          file_url: "https://files.todoist.com/data.csv",
+        },
+      },
+    ],
+    onAiRequest: (body) => { capturedBody = body; },
+    useAnthropic: false,
+    fileDownloadResponse: () => new Response(
+      new TextEncoder().encode(csvContent),
+      { status: 200, headers: { "Content-Type": "text/csv" } },
+    ),
+  });
+
+  try {
+    const payload = JSON.stringify(makePayload({
+      event_data: { id: "csv-1", content: "@ai Analyze this data", item_id: "task-1" },
+    }));
+    const req = await signedRequest(payload);
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert(capturedBody !== null, "AI should be called");
+    const messages = capturedBody!.messages as Record<string, unknown>[];
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    assert(lastUser, "Should have a user message");
+    const parts = lastUser.content as Record<string, unknown>[];
+    // Text files work with OpenAI — no "requires Anthropic" placeholder
+    const textParts = parts.filter((p) => p.type === "text");
+    const filePart = textParts.find((p) =>
+      (p.text as string).includes("[File: data.csv]")
+    );
+    assert(filePart, "OpenAI should get text file content directly");
+    assert((filePart!.text as string).includes(csvContent), "Should contain CSV content");
+    // No Anthropic-only placeholder
+    const hasAnthropicPlaceholder = textParts.some((p) =>
+      (p.text as string).includes("requires Anthropic")
+    );
+    assertEquals(hasAnthropicPlaceholder, false, "Text files should not have Anthropic placeholder");
   } finally {
     restore();
   }

--- a/supabase/functions/webhook/handler.ts
+++ b/supabase/functions/webhook/handler.ts
@@ -18,7 +18,7 @@ import {
 import { commentsToMessages, normalizeModel } from "../_shared/messages.ts";
 import { captureException } from "../_shared/sentry.ts";
 import { uint8ToBase64, verifyHmac, decrypt, decryptIfPresent } from "../_shared/crypto.ts";
-import { sanitizeImageMediaType, sanitizeDocumentMediaType, isPrivateHostname, extractMarkdownImageUrls, guessMediaType } from "../_shared/validation.ts";
+import { sanitizeImageMediaType, sanitizeDocumentMediaType, isPrivateHostname, extractMarkdownImageUrls, guessMediaType, isTextFile } from "../_shared/validation.ts";
 import type { TodoistComment, TodoistWebhookEvent, UserConfig } from "../_shared/types.ts";
 
 // ---------------------------------------------------------------------------
@@ -146,12 +146,53 @@ async function runAiForTask(
       .filter((r): r is PromiseFulfilledResult<DocumentAttachment> => r.status === "fulfilled")
       .map((r) => r.value);
 
-    // For non-supported file types, add placeholder documents so the AI knows a file was attached
+    // Download text-based files (txt, md, csv, json, py, sh, etc.) and inject as text content
+    const textFileComments = comments.filter(
+      (c: TodoistComment) =>
+        c.file_attachment &&
+        !c.file_attachment.file_type?.startsWith("image/") &&
+        !SUPPORTED_DOCUMENT_TYPES.has(c.file_attachment.file_type ?? "") &&
+        isTextFile(c.file_attachment.file_type, c.file_attachment.file_name) &&
+        windowCommentIds.has(c.id)
+    );
+    const textFileResults = await Promise.allSettled(
+      textFileComments.map(async (c: TodoistComment) => {
+        const att = c.file_attachment!;
+        const bytes = await todoist.downloadFile(att.file_url);
+        let textContent: string;
+        try {
+          textContent = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        } catch {
+          // Binary content disguised with text MIME type — skip as unsupported
+          return { data: "", mediaType: att.file_type, fileName: att.file_name };
+        }
+        return { data: "", mediaType: att.file_type, fileName: att.file_name, textContent };
+      })
+    );
+    if (textFileResults.some((r) => r.status === "rejected")) {
+      const rejectedTexts = textFileResults.filter((r) => r.status === "rejected");
+      console.warn("Some text file downloads failed", {
+        requestId,
+        taskId,
+        failedCount: rejectedTexts.length,
+        errors: rejectedTexts.map((r) =>
+          (r as PromiseRejectedResult).reason instanceof Error
+            ? (r as PromiseRejectedResult).reason.message
+            : String((r as PromiseRejectedResult).reason)
+        ),
+      });
+    }
+    for (const r of textFileResults) {
+      if (r.status === "fulfilled") documents.push(r.value);
+    }
+
+    // For truly unsupported binary files (docx, xlsx, zip, etc.), add placeholder
     const unsupportedFileComments = comments.filter(
       (c: TodoistComment) =>
         c.file_attachment &&
         !c.file_attachment.file_type?.startsWith("image/") &&
         !SUPPORTED_DOCUMENT_TYPES.has(c.file_attachment.file_type ?? "") &&
+        !isTextFile(c.file_attachment.file_type, c.file_attachment.file_name) &&
         windowCommentIds.has(c.id)
     );
     for (const c of unsupportedFileComments) {


### PR DESCRIPTION
## Summary

Closes #188

- Extends file support beyond PDF to handle text-based files (.txt, .md, .csv, .json, .py, .sh, .ts, .yaml, .sql, .html, .log, etc.)
- Text files are downloaded, decoded as UTF-8, and injected as plain text blocks that work with **all AI providers** (Anthropic + OpenAI)
- PDFs remain unchanged — still use Anthropic native document blocks
- Binary files (.docx, .xlsx, .zip) continue to show an unsupported placeholder

### How it works

1. `isTextFile(mimeType, fileName)` detects text files via MIME type allowlist + file extension fallback
2. Handler downloads the file, decodes with strict UTF-8 (`fatal: true` — rejects binary content with misleading MIME types)
3. Content is injected as `[File: name]\n<content>` text blocks in `buildMessages`
4. 50k character cap (consistent with `fetch_url` tool), 4 MB download limit (existing)

### Files changed

| File | Change |
|------|--------|
| `constants.ts` | `MAX_TEXT_FILE_CHARS`, `SUPPORTED_TEXT_MIME_TYPES` |
| `validation.ts` | `isTextFile()` function |
| `ai.ts` | `textContent?` on `DocumentAttachment`, 3-way branch in `buildMessages` |
| `handler.ts` | Text file download pass, narrowed unsupported filter |
| Tests (3 files) | 15 new tests |
| `README.md` | Updated feature table and security limits |

## Test plan

- [x] `isTextFile` — MIME hit, extension fallback, binary rejection, null/undefined fileName, dotfiles
- [x] `buildMessages` — text file → text block, truncation at 50k, combined with PDF, empty file
- [x] E2E webhook — .sh file download, .py extension fallback, .csv with OpenAI provider
- [x] Existing tests still pass (415 total, 0 failures)
- [x] Frontend tests pass (105 total)
- [x] Lint clean (Deno + ESLint)
- [x] Frontend build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)