### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-ai-agent",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "description": "Multi-tenant AI agent for Todoist",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 1.3.1 to 1.4.0 in both `package.json` and `frontend/package.json`

### New features since 1.3.1:
- Text-based file attachment support (#189)
- PDF file attachment support via Anthropic native documents (#187)
- `fetch_url` tool for reading web page content (#185)
- Sonnet 4.6 fallback when Opus 4.6 is overloaded (#184)
- Handle 401 on settings page after account disconnect (#190)

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)