### PR TITLE
fix: update e2e specs to match revamped landing and welcome pages

### DIFF
--- a/frontend/e2e/landing.spec.ts
+++ b/frontend/e2e/landing.spec.ts
@@ -5,21 +5,20 @@ test.describe("Landing page", () => {
   test("renders heading and subtext", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("h1#landing-heading")).toHaveText(
-      "Todoist AI Agent",
+      "AI that lives in your Todoist",
     );
     await expect(
-      page.getByText("An AI assistant that lives inside your Todoist"),
+      page.getByText(/Stop context-switching/),
     ).toBeVisible();
   });
 
-  test("renders features list with 6 items", async ({ page }) => {
+  test("renders use cases list with 4 items", async ({ page }) => {
     await page.goto("/");
-    const features = page.locator('ul[aria-label="Features"]');
-    await expect(features).toBeVisible();
-    await expect(features.locator("li")).toHaveCount(6);
-    await expect(page.getByText("Natural Conversations")).toBeVisible();
-    await expect(page.getByText("Built-in Web Search")).toBeVisible();
-    await expect(page.getByText("Bring Your Own Key")).toBeVisible();
+    const useCases = page.locator('ul[aria-label="Use cases"]');
+    await expect(useCases).toBeVisible();
+    await expect(useCases.locator("li")).toHaveCount(4);
+    await expect(page.getByText("Break Down Complex Tasks")).toBeVisible();
+    await expect(page.getByText("Research Without Leaving Todoist")).toBeVisible();
   });
 
   test("renders Connect Todoist buttons", async ({ page }) => {

--- a/frontend/e2e/welcome.spec.ts
+++ b/frontend/e2e/welcome.spec.ts
@@ -26,25 +26,22 @@ test.describe("Welcome: rendering", () => {
     ).toBeVisible();
   });
 
-  test("shows how-to-use section with 3 steps", async ({ page }) => {
+  test("shows try-it-now section with example commands", async ({ page }) => {
     await setupAuth(page);
     await page.goto("/welcome");
     await expect(
-      page.getByRole("heading", { name: "Here's How to Use It" }),
+      page.getByRole("heading", { name: "Try your first @ai command" }),
     ).toBeVisible();
-    const steps = page.locator('ol[aria-label="Getting started steps"]');
-    await expect(steps).toBeVisible();
-    await expect(steps.locator("li")).toHaveCount(3);
+    await expect(page.getByText("@ai break this task into smaller steps")).toBeVisible();
+    await expect(page.getByText("@ai what should I do first?")).toBeVisible();
+    await expect(page.getByText("@ai help me plan this project")).toBeVisible();
   });
 
-  test("shows step titles", async ({ page }) => {
+  test("shows copy buttons for example commands", async ({ page }) => {
     await setupAuth(page);
     await page.goto("/welcome");
-    await expect(page.getByText("Open Any Task in Todoist")).toBeVisible();
-    await expect(
-      page.getByText("Comment @ai With Your Question"),
-    ).toBeVisible();
-    await expect(page.getByText("Get an Instant AI Response")).toBeVisible();
+    const copyButtons = page.getByRole("button", { name: "Copy" });
+    await expect(copyButtons).toHaveCount(3);
   });
 
   test("shows Go to Settings button", async ({ page }) => {
@@ -58,7 +55,7 @@ test.describe("Welcome: rendering", () => {
   test("shows Open Todoist link with target blank", async ({ page }) => {
     await setupAuth(page);
     await page.goto("/welcome");
-    const link = page.getByRole("link", { name: "Open Todoist" });
+    const link = page.getByRole("link", { name: /Open Todoist/ });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
   });
@@ -101,16 +98,5 @@ test.describe("Welcome: accessibility", () => {
       "aria-labelledby",
       "welcome-heading",
     );
-  });
-
-  test("step numbers are decorative (aria-hidden)", async ({ page }) => {
-    await setupAuth(page);
-    await page.goto("/welcome");
-    const steps = page.locator('ol[aria-label="Getting started steps"] li');
-    await expect(steps).toHaveCount(3);
-    for (let i = 0; i < 3; i++) {
-      const badge = steps.nth(i).locator("span[aria-hidden='true']");
-      await expect(badge).toBeVisible();
-    }
   });
 });


### PR DESCRIPTION
Landing heading changed to "AI that lives in your Todoist", features list replaced with use cases. Welcome step list replaced with try-it-now section with copyable example commands.

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- List the key changes made -->

-

## Test Plan

<!-- How was this tested? -->

- [ ] Deno tests pass (`npm test`)
- [ ] Frontend lint passes (`cd frontend && npm run lint`)
- [ ] Frontend builds (`npm run frontend:build`)
- [ ] Manually tested locally (if applicable)
